### PR TITLE
Don't print usage for HTTP errors

### DIFF
--- a/cmd/ocm/delete/cmd.go
+++ b/cmd/ocm/delete/cmd.go
@@ -109,7 +109,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	// Bye:
 	if status >= 400 {
-		return fmt.Errorf("Received unexpected status code: %v", status)
+		os.Exit(1)
 	}
 
 	return nil

--- a/cmd/ocm/get/cmd.go
+++ b/cmd/ocm/get/cmd.go
@@ -124,7 +124,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	// Bye:
 	if status >= 400 {
-		return fmt.Errorf("Received unexpected status code: %v", status)
+		os.Exit(1)
 	}
 
 	return nil

--- a/cmd/ocm/patch/cmd.go
+++ b/cmd/ocm/patch/cmd.go
@@ -115,7 +115,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	// Bye:
 	if status >= 400 {
-		return fmt.Errorf("Received unexpected status code: %v", status)
+		os.Exit(1)
 	}
 
 	return nil

--- a/cmd/ocm/post/cmd.go
+++ b/cmd/ocm/post/cmd.go
@@ -115,7 +115,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	// Bye:
 	if status >= 400 {
-		return fmt.Errorf("Received unexpected status code: %v", status)
+		os.Exit(1)
 	}
 
 	return nil


### PR DESCRIPTION
Currently when the HTTP commands receive an error response they return
an error, and as a result the main program prints the usage message.
This isn't correct; we should just print the returned response and exit
with an error code.