### PR TITLE
Release 0.1.22

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+== 0.2.12 Sep 9 2019
+
+- Change default version field to point to current version.
+
+- Add ability to open the console URL in browser.
+
 == 0.1.21 Aug 28 2019
 
 - Don't print usage message when the `get`, `post`, `patch` and `delete`

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.21"
+const Version = "0.1.22"


### PR DESCRIPTION
The more relevant changes in this version are the following:

- Change default version field to point to current version.

- Add ability to open the console URL in browser.