### PR TITLE
fix bug that login not overwrite old token

### DIFF
--- a/cmd/ocm/login/cmd.go
+++ b/cmd/ocm/login/cmd.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/ocm-cli/pkg/config"
@@ -230,6 +230,8 @@ func run(cmd *cobra.Command, argv []string) error {
 	cfg.User = args.user
 	cfg.Password = args.password
 	cfg.Insecure = args.insecure
+	cfg.AccessToken = ""
+	cfg.RefreshToken = ""
 
 	// Put the token in the place of the configuration that corresponds to its type:
 	if haveToken {


### PR DESCRIPTION
We found `ocm login --token='xxxxx'` with a diff user does not replace the existing tokens.


$ ocm login --token='petli.openshift token'
$ ocm whoami
{
  ......
  "username": "petli.openshift",
  ......
}

$ ocm login --token='rhn-engineering-petli token'
$ ocm whoami
{
  ......
  "username": "petli.openshift",   // <- should be rhn-engineering-petli
  ......
}

The issue could be that the `connection.tokens()` checks for exp. date of existing token and reuses it if it's not expired.