### PR TITLE
Fix quota output to look at correct API field

### DIFF
--- a/cmd/ocm/account/quota/cmd.go
+++ b/cmd/ocm/account/quota/cmd.go
@@ -104,7 +104,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("Can't retrieve organization information: %v", err)
 	}
-	quotaClient := orgCollection.ResourceQuota()
+	quotaClient := orgCollection.QuotaSummary()
 
 	// Simple output:
 	if !args.json {
@@ -119,9 +119,13 @@ func run(cmd *cobra.Command, argv []string) error {
 		// Display quota information:
 		fmt.Printf("Cluster quota for organization '%s' ID: '%s'\n",
 			orgResponse.Body().Name(), orgResponse.Body().ID())
-		quotasListResponse.Items().Each(func(quota *amv1.ResourceQuota) bool {
-			fmt.Printf("%s-AZ: %d/%d\n", strings.ToUpper(quota.AvailabilityZoneType()),
-				quota.Reserved(), quota.Allowed())
+		quotasListResponse.Items().Each(func(quota *amv1.QuotaSummary) bool {
+			var byoc string
+			if quota.BYOC() {
+				byoc = " BYOC"
+			}
+			fmt.Printf("%s-AZ%s: %d/%d\n", strings.ToUpper(quota.AvailabilityZoneType()),
+				byoc, quota.Reserved(), quota.Allowed())
 			return true
 		})
 


### PR DESCRIPTION
Based on a recommendation from @abhgupta, change the field that the `ocm account quota` looks at, so that we can accurately report the quota of the specified organization.

```
Cluster quota for organization 'Example Organization' ID: 'xxxxxxxxxxxxxxxxxxxxxxxxxxx'
MULTI-AZ: 0/15
SINGLE-AZ: 11/15
SINGLE-AZ BYOC: 1/1
```