### PR TITLE
Update to SDK 0.1.36

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
-	github.com/openshift-online/ocm-sdk-go v0.1.35
+	github.com/openshift-online/ocm-sdk-go v0.1.36
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/prometheus/common v0.6.0 // indirect
 	github.com/prometheus/procfs v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.30 h1:v/xD1v3LqNm0f1+aBMPDEOeTs96pTS
 github.com/openshift-online/ocm-sdk-go v0.1.30/go.mod h1:rUF3jK/T4pieeafrKdBZ2TLnjqAUt7MxgvsmCdzXVQw=
 github.com/openshift-online/ocm-sdk-go v0.1.35 h1:leC0orpznxsP76elbxFlgIPu2YMvKnjU1KAy55kJvRU=
 github.com/openshift-online/ocm-sdk-go v0.1.35/go.mod h1:rUF3jK/T4pieeafrKdBZ2TLnjqAUt7MxgvsmCdzXVQw=
+github.com/openshift-online/ocm-sdk-go v0.1.36 h1:8Rp7WYgNQYeo7o1VwG/M2Rgox9eScNRTp63fH3KD+Ak=
+github.com/openshift-online/ocm-sdk-go v0.1.36/go.mod h1:rUF3jK/T4pieeafrKdBZ2TLnjqAUt7MxgvsmCdzXVQw=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=


### PR DESCRIPTION
The more relevant change in the new version of the SDK is that the
`cluster.craetor` field has been removed. This means that we need to
update the `cluster describe` command to get the creator following the
link to the subscription and then to the account.

Related: https://jira.coreos.com/browse/SDA-1395