### PR TITLE
Release 0.1.26

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+== 0.1.26 Oct 3 2019
+
+- Fixed the `cluster create` command so that it retrieves all the enabled
+  versions.
+
 == 0.1.25 Sep 26 2019
 
 - Added new `cluster create` command.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.25"
+const Version = "0.1.26"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Fixed the `cluster create` command so that it retrieves all the enabled
  versions.