### PR TITLE
Don't print empty response body

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -29,6 +29,9 @@ import (
 // JSON document then it will be indented before printing it. If the `jq` tools is available in the
 // path then it will be used for syntax highlighting.
 func Pretty(stream io.Writer, body []byte) error {
+	if len(body) == 0 {
+		return nil
+	}
 	var data map[string]interface{}
 	err := json.Unmarshal(body, &data)
 	if err != nil {
@@ -44,6 +47,9 @@ func Pretty(stream io.Writer, body []byte) error {
 // output to a single line, intended to be used with other resources that require single line
 // output.
 func Simple(stream io.Writer, body []byte) error {
+	if len(body) == 0 {
+		return nil
+	}
 	var data map[string]interface{}
 	err := json.Unmarshal(body, &data)
 	if err != nil {


### PR DESCRIPTION
Currently when a response body is empty the tool will still print it,
followed by a blank line. This patch changes it so that it will not
print it at all.