### PR TITLE
Drop support for _developers.redhat.com_

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,15 @@
 
 # Ensure go modules are enabled:
 export GO111MODULE=on
+export GOPROXY=https://proxy.golang.org
+
+# Disable CGO so that we always generate static binaries:
+export CGO_ENABLED=0
 
 .PHONY: cmds
 cmds:
 	for cmd in $$(ls cmd); do \
-		CGO_ENABLED=0 \
-		go build -mod=readonly -o "$${cmd}" "./cmd/$${cmd}" || exit 1; \
+		go build -o "$${cmd}" "./cmd/$${cmd}" || exit 1; \
 	done
 
 .PHONY: install

--- a/README.adoc
+++ b/README.adoc
@@ -25,17 +25,6 @@ To do that use the `login` command:
 $ ocm login --token=eyJ...
 ....
 
-Alternatively, if you don't have an offline access token, you can log-in using
-your https://developers.redhat.com[developers.redhat.com] user name and
-password:
-
-....
-$ ocm login --user=... --password=...
-....
-
-However this option is deprecated, because it is less secure, and it will be
-removed in the future.
-
 This will use the provided token to request _OpenID_ access and refresh tokens
 to _sso.redhat.com_. The tokens will be saved to the `.ocm.json` file in
 your home directory, for future use.

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/mattn/go-colorable v0.1.2 // indirect
-	github.com/onsi/ginkgo v1.8.0
+	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.5.0
-	github.com/openshift-online/ocm-sdk-go v0.1.49
+	github.com/openshift-online/ocm-sdk-go v0.1.54
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/prometheus/common v0.6.0 // indirect
 	github.com/prometheus/procfs v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
+github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -113,6 +115,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.36 h1:8Rp7WYgNQYeo7o1VwG/M2Rgox9eScN
 github.com/openshift-online/ocm-sdk-go v0.1.36/go.mod h1:rUF3jK/T4pieeafrKdBZ2TLnjqAUt7MxgvsmCdzXVQw=
 github.com/openshift-online/ocm-sdk-go v0.1.49 h1:E19sOmT3S0z69cIW309+b0dxB4VBFi9zbJgETjuof1o=
 github.com/openshift-online/ocm-sdk-go v0.1.49/go.mod h1:rUF3jK/T4pieeafrKdBZ2TLnjqAUt7MxgvsmCdzXVQw=
+github.com/openshift-online/ocm-sdk-go v0.1.54 h1:Rh6yCxbuWgpJuwTHE0TYGpw5wmPKPwMNXv2paQhJydk=
+github.com/openshift-online/ocm-sdk-go v0.1.54/go.mod h1:rUF3jK/T4pieeafrKdBZ2TLnjqAUt7MxgvsmCdzXVQw=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=


### PR DESCRIPTION
This patch drops support for authenticating with
_developers.redhat.com_, as that has already been removed from the
server and from the SDK.