### PR TITLE
adding new options for "ocm account users" command

### DIFF
--- a/cmd/ocm/account/status/cmd.go
+++ b/cmd/ocm/account/status/cmd.go
@@ -23,12 +23,14 @@ import (
 
 	acc_util "github.com/openshift-online/ocm-cli/pkg/account"
 	"github.com/openshift-online/ocm-cli/pkg/config"
+	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
 var args struct {
 	debug bool
 }
 
+// Cmd is a new Cobra Command
 var Cmd = &cobra.Command{
 	Use:   "status",
 	Short: "Status of current user.",
@@ -86,11 +88,11 @@ func run(cmd *cobra.Command, argv []string) error {
 	fmt.Println(fmt.Sprintf("%s on %s", currAccount.Username(), cfg.URL))
 
 	// Display roles currently assigned to the user
-	roleSlice, err := acc_util.GetRolesFromUser(currAccount, connection)
+	roleSlice, err := acc_util.GetRolesFromUsers([]*amv1.Account{currAccount}, connection)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Roles: %v\n", nicePrint(roleSlice))
+	fmt.Printf("Roles: %v\n", nicePrint(roleSlice[currAccount]))
 
 	return nil
 }

--- a/cmd/ocm/account/users/cmd.go
+++ b/cmd/ocm/account/users/cmd.go
@@ -66,7 +66,8 @@ func init() {
 		&args.roles,
 		"roles",
 		[]string{},
-		"Role identifiers. Returns users with one or more of the specified roles. Multiple roles can be specified like: --roles=\"role1,role2,role2\".",
+		`Role identifiers. Returns users with one or more of the specified roles.
+		Multiple roles can be specified like: --roles="role1,role2,role2".`,
 	)
 }
 

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -17,48 +17,78 @@ limitations under the License.
 package account
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/openshift-online/ocm-sdk-go"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
-// GetRolesFromUser gets all roles a specific user possesses.
-func GetRolesFromUser(account *amv1.Account, conn *sdk.Connection) ([]string, error) {
+// GetRolesFromUsers gets all roles a specific user possesses.
+func GetRolesFromUsers(accounts []*amv1.Account, conn *sdk.Connection) (results map[*amv1.Account][]string, error error) {
+	// Prepare the results:
+	results = map[*amv1.Account][]string{}
 
-	pageIndex := 1
-	var roles []string
+	// Prepare a map of accounts indexed by identifier:
+	accountsMap := map[string]*amv1.Account{}
+	for _, account := range accounts {
+		accountsMap[account.ID()] = account
+	}
 
-	// Get all roles in each role page:
-	for {
-		rolesList := conn.AccountsMgmt().V1().RoleBindings().List().Page(pageIndex)
-		// Format search request:
-		searchRequest := ""
-		searchRequest = fmt.Sprintf("account_id='%s'", account.ID())
-		// Add parameter to search for role with matching user id:
-		rolesList.Parameter("search", searchRequest)
-		// Get response:
-		response, err := rolesList.Send()
-		if err != nil {
-			return roles, fmt.Errorf("Can't retrieve roles: %v", err)
+	// Prepare a query to retrieve all the role bindings that correspond to any of the
+	// accounts:
+	ids := &bytes.Buffer{}
+	for i, account := range accounts {
+		if i > 0 {
+			ids.WriteString(", ")
 		}
-		// Loop through roles and save their ids
-		// iff it is not in the list yet:
+		fmt.Fprintf(ids, "'%s'", account.ID())
+	}
+	query := fmt.Sprintf("account_id in (%s)", ids)
+
+	index := 1
+	size := 100
+
+	for {
+		// Prepare the request:
+		response, err := conn.AccountsMgmt().V1().RoleBindings().List().
+			Size(size).
+			Page(index).
+			Parameter("search", query).
+			Send()
+
+		if err != nil {
+			return nil, fmt.Errorf("Can't retrieve roles: %v", err)
+		}
+		// Loop through the results and save them:
 		response.Items().Each(func(item *amv1.RoleBinding) bool {
-			if !stringInList(roles, item.Role().ID()) {
-				roles = append(roles, item.Role().ID())
+			account := accountsMap[item.Account().ID()]
+
+			itemID := item.Role().ID()
+			fmt.Println(accountsMap[item.Account().ID()].Username(), accountsMap[item.Account().ID()].Organization().ID(), itemID)
+
+			if _, ok := results[account]; ok {
+				if !stringInList(results[account], itemID) {
+					results[account] = append(results[account], itemID)
+				}
+			} else {
+				results[account] = append(results[account], itemID)
 			}
+
 			return true
 		})
 
-		// Break
-		if response.Size() < 100 {
+		// Break the loop if the page size is smaller than requested, as that indicates
+		// that this is the last page:
+		if response.Size() < size {
+			fmt.Println("account breaking at final page size", response.Size())
 			break
 		}
-
-		pageIndex++
+		index++
+		fmt.Println("account index is now", index)
 	}
-	return roles, nil
+
+	return
 }
 
 // stringInList returns a bool signifying whether

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -65,7 +65,6 @@ func GetRolesFromUsers(accounts []*amv1.Account, conn *sdk.Connection) (results 
 			account := accountsMap[item.Account().ID()]
 
 			itemID := item.Role().ID()
-			fmt.Println(accountsMap[item.Account().ID()].Username(), accountsMap[item.Account().ID()].Organization().ID(), itemID)
 
 			if _, ok := results[account]; ok {
 				if !stringInList(results[account], itemID) {
@@ -81,11 +80,9 @@ func GetRolesFromUsers(accounts []*amv1.Account, conn *sdk.Connection) (results 
 		// Break the loop if the page size is smaller than requested, as that indicates
 		// that this is the last page:
 		if response.Size() < size {
-			fmt.Println("account breaking at final page size", response.Size())
 			break
 		}
 		index++
-		fmt.Println("account index is now", index)
 	}
 
 	return


### PR DESCRIPTION
Adding options needed by SRE Security for quarterly compliance review processes.

Now ocm gives us the ability to sift through the entirety of the user base and find those with specific roles in under a minute.

Every 3 months, we'll run a beefy query like the following:
ocm account users --roles="role1,role2,role3" --workers=100 --pagesize=100000