### PR TITLE
add org details to account status cmd

### DIFF
--- a/cmd/ocm/account/status/cmd.go
+++ b/cmd/ocm/account/status/cmd.go
@@ -83,7 +83,9 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	// Display user and which server they are logged into
 	currAccount := response.Body()
-	fmt.Println(fmt.Sprintf("%s on %s", currAccount.Username(), cfg.URL))
+	currOrg := currAccount.Organization()
+	fmt.Println(fmt.Sprintf("User %s on %s in org '%s' %s (external_id: %s)",
+		currAccount.Username(), cfg.URL, currOrg.Name(), currOrg.ID(), currOrg.ExternalID()))
 
 	// Display roles currently assigned to the user
 	roleSlice, err := acc_util.GetRolesFromUser(currAccount, connection)


### PR DESCRIPTION
Example output

```
$ go run cmd/ocm/main.go account status
User aweiteka-srep on https://api.stage.openshift.com in org 'Red Hat OpenShift Online' 1HELaFOf2YHWwwvt3XMbT5Mja7M (external_id: 6323660)
Roles: SuperAdmin, SREP, UHCSupport, RHUser, ClusterOwner, OrganizationMember, AuthenticatedUser
```