### PR TITLE
Release 0.1.34

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,15 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+== 0.1.34 Jan 16 2020
+
+- Add number of _infra_ nodes to the output of the `cluster describe` command.
+- Add `--roles` flag to the `account users` command.
+- Add support for `OCM_CONFIG` environment variable to indicate an alternative
+  location of the configuration file.
+- Tighten output of the `account orgs`, `account quota`, `account users` and
+  `cluster list` commands.
+
 == 0.1.33 Jan 8 2020
 
 - Update to SDK 0.1.78.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.33"
+const Version = "0.1.34"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Add number of _infra_ nodes to the output of the `cluster describe` command.
- Add `--roles` flag to the `account users` command.
- Add support for `OCM_CONFIG` environment variable to indicate an alternative
  location of the configuration file.
- Tighten output of the `account orgs`, `account quota`, `account users` and
  `cluster list` commands.
