### PR TITLE
display quota so it supports add-ons

### DIFF
--- a/cmd/ocm/account/quota/cmd.go
+++ b/cmd/ocm/account/quota/cmd.go
@@ -124,8 +124,8 @@ func run(cmd *cobra.Command, argv []string) error {
 			if quota.BYOC() {
 				byoc = " BYOC"
 			}
-			fmt.Printf("%s-AZ%s: %d/%d %s\n", strings.ToUpper(quota.AvailabilityZoneType()),
-				byoc, quota.Reserved(), quota.Allowed(), quota.ResourceName())
+			fmt.Printf("%d/%d %s %s%s\n", quota.Reserved(), quota.Allowed(), quota.ResourceName(),
+				strings.ToUpper(quota.AvailabilityZoneType()), byoc)
 			return true
 		})
 


### PR DESCRIPTION
before patch:
```
-AZ: 0/20 addon-rhmi-operator
MULTI-AZ: 0/15 m5.xlarge
SINGLE-AZ: 13/100 m5.xlarge
SINGLE-AZ BYOC: 0/15 m5.xlarge
```

After patch:
```
0/20 addon-rhmi-operator 
0/15 m5.xlarge MULTI
13/100 m5.xlarge SINGLE
0/15 m5.xlarge SINGLE BYOC
```
