### PR TITLE
Preserve JSON order

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/procfs v0.0.8 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
+	gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
 	gopkg.in/AlecAivazis/survey.v1 v1.8.5
 	k8s.io/apimachinery v0.0.0-20190923155427-ec87dd743e08

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2 h1:M+r1hdmjZc4L4SCn0ZIq/5YQIRxprV+kOf7n7f04l5o=
+gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -23,6 +23,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+
+	"gitlab.com/c0b/go-ordered-json"
 )
 
 // Pretty dumps the given data to the given stream so that it looks pretty. If the data is a valid
@@ -32,8 +34,8 @@ func Pretty(stream io.Writer, body []byte) error {
 	if len(body) == 0 {
 		return nil
 	}
-	var data map[string]interface{}
-	err := json.Unmarshal(body, &data)
+	data := ordered.NewOrderedMap()
+	err := json.Unmarshal(body, data)
 	if err != nil {
 		return dumpBytes(stream, body)
 	}
@@ -50,8 +52,8 @@ func Simple(stream io.Writer, body []byte) error {
 	if len(body) == 0 {
 		return nil
 	}
-	var data map[string]interface{}
-	err := json.Unmarshal(body, &data)
+	data := ordered.NewOrderedMap()
+	err := json.Unmarshal(body, data)
 	if err != nil {
 		return dumpBytes(stream, body)
 	}
@@ -88,7 +90,7 @@ func dumpCondensedJQ(stream io.Writer, data []byte) error {
 	return jq.Run()
 }
 
-func dumpJSON(stream io.Writer, data map[string]interface{}) error {
+func dumpJSON(stream io.Writer, data *ordered.OrderedMap) error {
 	encoder := json.NewEncoder(stream)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(data)


### PR DESCRIPTION
This patch changes the SDK so that it preserves the order of attributes
of output JSON documents.