### PR TITLE
Release 0.1.36

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+== 0.1.36 Feb 14 2020
+
+- Add `state` to list of default columns for cluster list.
+- Preserve order of attributes in JSON output.
+
 == 0.1.35 Feb 3 2020
 
 - Display quota so it supports add-ons.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.5.0
-	github.com/openshift-online/ocm-sdk-go v0.1.78
+	github.com/openshift-online/ocm-sdk-go v0.1.87
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/prometheus/client_golang v1.2.1 // indirect
 	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/openshift-online/ocm-sdk-go v0.1.78 h1:8vnhXm5ESa5HlSp0JuPNVJw5ZfI9bokfFB8Gmjj7s7Q=
-github.com/openshift-online/ocm-sdk-go v0.1.78/go.mod h1:XfneqPVII+VM7bHHjZIrstyQrsp58OFpgMySvCet3uM=
+github.com/openshift-online/ocm-sdk-go v0.1.87 h1:sUYxeKepkdKY+GRNI7t+3rYUsWpN7M3f/470X8Vxi6U=
+github.com/openshift-online/ocm-sdk-go v0.1.87/go.mod h1:2MWkLNfXrj92r3VOYYcu5RfpTj9o98RYD228HJ09WiI=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.35"
+const Version = "0.1.36"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Add `state` to list of default columns for cluster list.
- Preserve order of attributes in JSON output.