### PR TITLE
Describe by name, identifier or external identifier

### DIFF
--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -80,17 +80,20 @@ func PrintClusterDesctipion(connection *sdk.Connection, cluster *cmv1.Cluster) e
 	}
 
 	// Print short cluster description:
-	fmt.Printf("\nID:       %s\n"+
-		"Name:     %s.%s\n"+
-		"API URL:  %s\n"+
-		"Masters:  %d\n"+
-		"Infra:    %d\n"+
-		"Computes: %d\n"+
-		"Region:   %s\n"+
-		"Multi-az: %t\n"+
-		"Creator:  %s\n"+
-		"Created:  %s %d %d\n",
+	fmt.Printf("\n"+
+		"ID:          %s\n"+
+		"External ID: %s\n"+
+		"Name:        %s.%s\n"+
+		"API URL:     %s\n"+
+		"Masters:     %d\n"+
+		"Infra:       %d\n"+
+		"Computes:    %d\n"+
+		"Region:      %s\n"+
+		"Multi-az:    %t\n"+
+		"Creator:     %s\n"+
+		"Created:     %s %d %d\n",
 		cluster.ID(),
+		cluster.ExternalID(),
 		cluster.Name(),
 		cluster.DNS().BaseDomain(),
 		apiURL,


### PR DESCRIPTION
This patch changes the `cluster describe` command so that it searches by
name, identifier and external identifier. For example, if a cluster is
named `mycluster`, has identifier `123` and external identifier
`87cc8272-0ec4-444b-ae2c-baf97acbcf7a` then these three commands will
return the same result:

```
$ ocm cluster describe mycluster
$ ocm cluster describe 123
$ ocm cluster describe 87cc8272-0ec4-444b-ae2c-baf97acbcf7a
```

The patch also adds the external identifier to the output of the
command, so it will look like this:

```
$ ./ocm cluster describe mycluster

ID:          123
External ID: 87cc8272-0ec4-444b-ae2c-baf97acbcf7a
Name:        mycluster.a0b1.p1.openshiftapps.com
API URL:     https://api.mycluster.a0b1.p1.openshiftapps.com:6443
Masters:     3
Computes:    4
Region:      us-east-1
Multi-az:    true
Creator:     jane.doe
Created:     Feb 26 2020

```

Related: https://github.com/openshift-online/ocm-cli/issues/59