### PR TITLE
Support query parameters in raw HTTP methods

### DIFF
--- a/cmd/ocm/account/orgs/cmd.go
+++ b/cmd/ocm/account/orgs/cmd.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/config"
-	flags "github.com/openshift-online/ocm-cli/pkg/flags"
 	table "github.com/openshift-online/ocm-cli/pkg/table"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
@@ -48,7 +48,7 @@ var Cmd = &cobra.Command{
 func init() {
 	// Add flags to rootCmd:
 	fs := Cmd.Flags()
-	flags.AddParameterFlag(fs, &args.parameter)
+	arguments.AddParameterFlag(fs, &args.parameter)
 	fs.StringVar(
 		&args.columns,
 		"columns",
@@ -116,7 +116,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			Size(pageSize)
 
 		// Apply parameters
-		flags.ApplyParameterFlag(request, args.parameter)
+		arguments.ApplyParameterFlag(request, args.parameter)
 
 		// Fetch next page
 		orgList, err := request.Send()

--- a/cmd/ocm/cluster/create/create.go
+++ b/cmd/ocm/cluster/create/create.go
@@ -23,9 +23,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	clusterpkg "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/config"
-	"github.com/openshift-online/ocm-cli/pkg/flags"
 )
 
 var args struct {
@@ -47,8 +47,8 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
-	flags.AddParameterFlag(fs, &args.parameter)
-	flags.AddHeaderFlag(fs, &args.header)
+	arguments.AddParameterFlag(fs, &args.parameter)
+	arguments.AddHeaderFlag(fs, &args.header)
 	fs.StringVar(
 		&args.region,
 		"region",

--- a/cmd/ocm/cluster/list/list.go
+++ b/cmd/ocm/cluster/list/list.go
@@ -28,8 +28,8 @@ import (
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/config"
-	"github.com/openshift-online/ocm-cli/pkg/flags"
 	table "github.com/openshift-online/ocm-cli/pkg/table"
 )
 
@@ -55,8 +55,8 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
-	flags.AddParameterFlag(fs, &args.parameter)
-	flags.AddHeaderFlag(fs, &args.header)
+	arguments.AddParameterFlag(fs, &args.parameter)
+	arguments.AddHeaderFlag(fs, &args.header)
 	fs.BoolVar(
 		&args.managed,
 		"managed",
@@ -147,8 +147,8 @@ func run(cmd *cobra.Command, argv []string) error {
 	for {
 		// Fetch the next page:
 		request := collection.List().Size(size).Page(index)
-		flags.ApplyParameterFlag(request, args.parameter)
-		flags.ApplyHeaderFlag(request, args.header)
+		arguments.ApplyParameterFlag(request, args.parameter)
+		arguments.ApplyHeaderFlag(request, args.header)
 		var search strings.Builder
 		if managed {
 			if search.Len() > 0 {

--- a/cmd/ocm/delete/cmd.go
+++ b/cmd/ocm/delete/cmd.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
-	"github.com/openshift-online/ocm-cli/pkg/flags"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
@@ -42,8 +42,8 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
-	flags.AddParameterFlag(fs, &args.parameter)
-	flags.AddHeaderFlag(fs, &args.header)
+	arguments.AddParameterFlag(fs, &args.parameter)
+	arguments.AddHeaderFlag(fs, &args.header)
 }
 
 func run(cmd *cobra.Command, argv []string) error {
@@ -77,9 +77,14 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Create and populate the request:
-	request := connection.Delete().Path(path)
-	flags.ApplyParameterFlag(request, args.parameter)
-	flags.ApplyHeaderFlag(request, args.header)
+	request := connection.Delete()
+	err = arguments.ApplyPathArg(request, path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't parse path '%s': %v\n", path, err)
+		os.Exit(1)
+	}
+	arguments.ApplyParameterFlag(request, args.parameter)
+	arguments.ApplyHeaderFlag(request, args.header)
 
 	// Send the request:
 	response, err := request.Send()

--- a/cmd/ocm/get/cmd.go
+++ b/cmd/ocm/get/cmd.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
-	"github.com/openshift-online/ocm-cli/pkg/flags"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
@@ -43,8 +43,8 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
-	flags.AddParameterFlag(fs, &args.parameter)
-	flags.AddHeaderFlag(fs, &args.header)
+	arguments.AddParameterFlag(fs, &args.parameter)
+	arguments.AddHeaderFlag(fs, &args.header)
 	fs.BoolVar(
 		&args.single,
 		"single",
@@ -84,9 +84,14 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Create and populate the request:
-	request := connection.Get().Path(path)
-	flags.ApplyParameterFlag(request, args.parameter)
-	flags.ApplyHeaderFlag(request, args.header)
+	request := connection.Get()
+	err = arguments.ApplyPathArg(request, path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't parse path '%s': %v\n", path, err)
+		os.Exit(1)
+	}
+	arguments.ApplyParameterFlag(request, args.parameter)
+	arguments.ApplyHeaderFlag(request, args.header)
 
 	// Send the request:
 	response, err := request.Send()

--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -38,7 +38,7 @@ import (
 	"github.com/openshift-online/ocm-cli/cmd/ocm/token"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/version"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/whoami"
-	"github.com/openshift-online/ocm-cli/pkg/flags"
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 )
 
 var root = &cobra.Command{
@@ -60,7 +60,7 @@ func init() {
 
 	// Add the command line flags:
 	fs := root.PersistentFlags()
-	flags.AddDebugFlag(fs)
+	arguments.AddDebugFlag(fs)
 
 	// Register the subcommands:
 	root.AddCommand(account.Cmd)

--- a/cmd/ocm/patch/cmd.go
+++ b/cmd/ocm/patch/cmd.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
-	"github.com/openshift-online/ocm-cli/pkg/flags"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
@@ -43,9 +43,9 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
-	flags.AddParameterFlag(fs, &args.parameter)
-	flags.AddHeaderFlag(fs, &args.header)
-	flags.AddBodyFlag(fs, &args.body)
+	arguments.AddParameterFlag(fs, &args.parameter)
+	arguments.AddHeaderFlag(fs, &args.header)
+	arguments.AddBodyFlag(fs, &args.body)
 }
 
 func run(cmd *cobra.Command, argv []string) error {
@@ -79,10 +79,15 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Create and populate the request:
-	request := connection.Patch().Path(path)
-	flags.ApplyParameterFlag(request, args.parameter)
-	flags.ApplyHeaderFlag(request, args.header)
-	err = flags.ApplyBodyFlag(request, args.body)
+	request := connection.Patch()
+	err = arguments.ApplyPathArg(request, path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't parse path '%s': %v\n", path, err)
+		os.Exit(1)
+	}
+	arguments.ApplyParameterFlag(request, args.parameter)
+	arguments.ApplyHeaderFlag(request, args.header)
+	err = arguments.ApplyBodyFlag(request, args.body)
 	if err != nil {
 		return fmt.Errorf("Can't read body: %v", err)
 	}

--- a/cmd/ocm/post/cmd.go
+++ b/cmd/ocm/post/cmd.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
-	"github.com/openshift-online/ocm-cli/pkg/flags"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
@@ -43,9 +43,9 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
-	flags.AddParameterFlag(fs, &args.parameter)
-	flags.AddHeaderFlag(fs, &args.header)
-	flags.AddBodyFlag(fs, &args.body)
+	arguments.AddParameterFlag(fs, &args.parameter)
+	arguments.AddHeaderFlag(fs, &args.header)
+	arguments.AddBodyFlag(fs, &args.body)
 }
 
 func run(cmd *cobra.Command, argv []string) error {
@@ -79,10 +79,15 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Create and populate the request:
-	request := connection.Post().Path(path)
-	flags.ApplyParameterFlag(request, args.parameter)
-	flags.ApplyHeaderFlag(request, args.parameter)
-	err = flags.ApplyBodyFlag(request, args.body)
+	request := connection.Post()
+	err = arguments.ApplyPathArg(request, path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't parse path '%s': %v\n", path, err)
+		os.Exit(1)
+	}
+	arguments.ApplyParameterFlag(request, args.parameter)
+	arguments.ApplyHeaderFlag(request, args.parameter)
+	err = arguments.ApplyBodyFlag(request, args.body)
 	if err != nil {
 		return fmt.Errorf("Can't read body: %v", err)
 	}

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This file contains functions that add common flags to the command line.
+// This file contains functions that add common arguments to the command line.
 
-package flags
+package arguments
 
 import (
 	"io/ioutil"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -126,5 +127,21 @@ func ApplyBodyFlag(request *sdk.Request, value string) error {
 		return err
 	}
 	request.Bytes(body)
+	return nil
+}
+
+// ApplyPathArg applies the value of the path given in the command line to the given request.
+func ApplyPathArg(request *sdk.Request, value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return err
+	}
+	request.Path(parsed.Path)
+	query := parsed.Query()
+	for name, values := range query {
+		for _, value := range values {
+			request.Parameter(name, value)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Currently the raw HTTP methods don't support correctly query parameters.
This patch fixes that.

Related: https://github.com/openshift-online/ocm-cli/issues/6