### PR TITLE
Add support for expiration in ocm cluster create

### DIFF
--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"fmt"
+	"time"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
@@ -25,10 +26,6 @@ import (
 )
 
 func PrintClusterDesctipion(connection *sdk.Connection, cluster *cmv1.Cluster) error {
-	// Get creation date info:
-	clusterTimetamp := cluster.CreationTimestamp()
-	year, month, day := clusterTimetamp.Date()
-
 	// Get API URL:
 	api := cluster.API()
 	apiURL, _ := api.GetURL()
@@ -91,7 +88,8 @@ func PrintClusterDesctipion(connection *sdk.Connection, cluster *cmv1.Cluster) e
 		"Region:      %s\n"+
 		"Multi-az:    %t\n"+
 		"Creator:     %s\n"+
-		"Created:     %s %d %d\n",
+		"Created:     %v\n"+
+		"Expiration:  %v\n",
 		cluster.ID(),
 		cluster.ExternalID(),
 		cluster.Name(),
@@ -103,7 +101,8 @@ func PrintClusterDesctipion(connection *sdk.Connection, cluster *cmv1.Cluster) e
 		cluster.Region().ID(),
 		cluster.MultiAZ(),
 		creator,
-		month.String(), day, year,
+		cluster.CreationTimestamp().Round(time.Second).Format(time.RFC3339Nano),
+		cluster.ExpirationTimestamp().Round(time.Second).Format(time.RFC3339Nano),
 	)
 	fmt.Println()
 


### PR DESCRIPTION
Now that we have maximum expiration support in the OCM API, this makes it easy to specify an expiration date via the CLI for a cluster you are creating. You can specify an exact date in RFC3389 format, or you can choose a duration (like 8h or 2d).