### PR TITLE
Add support for specifying cloud provider

### DIFF
--- a/cmd/ocm/cluster/create/create.go
+++ b/cmd/ocm/cluster/create/create.go
@@ -35,6 +35,7 @@ var args struct {
 	region            string
 	version           string
 	flavour           string
+	provider          string
 	expirationTime    string
 	expirationSeconds time.Duration
 }
@@ -56,7 +57,7 @@ func init() {
 		&args.region,
 		"region",
 		"us-east-1",
-		"The AWS region to create the cluster in",
+		"The cloud provider region to create the cluster in",
 	)
 	fs.StringVar(
 		&args.version,
@@ -69,6 +70,12 @@ func init() {
 		"flavour",
 		"osd-4",
 		"The OCM flavour to create the cluster with",
+	)
+	fs.StringVar(
+		&args.provider,
+		"provider",
+		"aws",
+		"The cloud provider to create the cluster on",
 	)
 	fs.StringVar(
 		&args.expirationTime,
@@ -91,6 +98,9 @@ func run(cmd *cobra.Command, argv []string) error {
 	// Validate options
 	if len(args.expirationTime) > 0 && args.expirationSeconds != 0 {
 		return fmt.Errorf("at most one of `expiration-time` or `expiration` may be specified")
+	}
+	if args.region == "us-east-1" && args.provider != "aws" {
+		return fmt.Errorf("if specifying a non-aws cloud provider, region must be set to a valid region")
 	}
 
 	// Load the configuration file:
@@ -191,6 +201,10 @@ func run(cmd *cobra.Command, argv []string) error {
 		Flavour(
 			cmv1.NewFlavour().
 				ID(clusterFlavour),
+		).
+		CloudProvider(
+			cmv1.NewCloudProvider().
+				ID(args.provider),
 		).
 		Region(
 			cmv1.NewCloudRegion().

--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -85,6 +85,7 @@ func PrintClusterDesctipion(connection *sdk.Connection, cluster *cmv1.Cluster) e
 		"Masters:     %d\n"+
 		"Infra:       %d\n"+
 		"Computes:    %d\n"+
+		"Provider:    %s\n"+
 		"Region:      %s\n"+
 		"Multi-az:    %t\n"+
 		"Creator:     %s\n"+
@@ -98,6 +99,7 @@ func PrintClusterDesctipion(connection *sdk.Connection, cluster *cmv1.Cluster) e
 		cluster.Nodes().Master(),
 		cluster.Nodes().Infra(),
 		cluster.Nodes().Compute(),
+		cluster.CloudProvider().ID(),
 		cluster.Region().ID(),
 		cluster.MultiAZ(),
 		creator,


### PR DESCRIPTION
This adds support for specifying a cloud provider to `ocm cluster create` via a `--provider` flag