### PR TITLE
config: beef up help message

### DIFF
--- a/cmd/ocm/config/get/get.go
+++ b/cmd/ocm/config/get/get.go
@@ -31,7 +31,8 @@ var args struct {
 
 var Cmd = &cobra.Command{
 	Use:   "get VARIABLE",
-	Short: "Prints the config variable",
+	Short: "Prints the value of a config variable",
+	Long:  "Prints the value of a config variable. See 'ocm config --help' for supported config variables.",
 	Args:  cobra.MinimumNArgs(1),
 	RunE:  run,
 }

--- a/cmd/ocm/config/set/set.go
+++ b/cmd/ocm/config/set/set.go
@@ -32,6 +32,7 @@ var args struct {
 var Cmd = &cobra.Command{
 	Use:   "set VARIABLE VALUE",
 	Short: "Sets the variable's value",
+	Long:  "Sets the value of a config variable. See 'ocm config --help' for supported config variables.",
 	Args:  cobra.MinimumNArgs(2),
 	RunE:  run,
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,23 +30,27 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/golang/glog"
 	"github.com/mitchellh/go-homedir"
-	"github.com/openshift-online/ocm-sdk-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 
 	"github.com/openshift-online/ocm-cli/pkg/debug"
 )
 
 // Config is the type used to store the configuration of the client.
+// There's no way to line-split or predefine tags, so...
+//nolint:lll
 type Config struct {
-	AccessToken  string   `json:"access_token,omitempty"`
-	ClientID     string   `json:"client_id,omitempty"`
-	ClientSecret string   `json:"client_secret,omitempty"`
-	Insecure     bool     `json:"insecure,omitempty"`
-	Password     string   `json:"password,omitempty"`
-	RefreshToken string   `json:"refresh_token,omitempty"`
-	Scopes       []string `json:"scopes,omitempty"`
-	TokenURL     string   `json:"token_url,omitempty"`
-	URL          string   `json:"url,omitempty"`
-	User         string   `json:"user,omitempty"`
+	// TODO(efried): Better docs for things like AccessToken
+	// TODO(efried): Dedup with flag docs in cmd/ocm/login/cmd.go:init where possible
+	AccessToken  string   `json:"access_token,omitempty" doc:"Bearer access token."`
+	ClientID     string   `json:"client_id,omitempty" doc:"OpenID client identifier."`
+	ClientSecret string   `json:"client_secret,omitempty" doc:"OpenID client secret."`
+	Insecure     bool     `json:"insecure,omitempty" doc:"Enables insecure communication with the server. This disables verification of TLS certificates and host names."`
+	Password     string   `json:"password,omitempty" doc:"User password."`
+	RefreshToken string   `json:"refresh_token,omitempty" doc:"Offline or refresh token."`
+	Scopes       []string `json:"scopes,omitempty" doc:"OpenID scope. If this option is used it will replace completely the default scopes. Can be repeated multiple times to specify multiple scopes."`
+	TokenURL     string   `json:"token_url,omitempty" doc:"OpenID token URL."`
+	URL          string   `json:"url,omitempty" doc:"URL of the API gateway. The value can be the complete URL or an alias. The valid aliases are 'production', 'staging' and 'integration'."`
+	User         string   `json:"user,omitempty" doc:"User name."`
 }
 
 // Load loads the configuration from the configuration file. If the configuration file doesn't exist


### PR DESCRIPTION
As a noob, I was frustrated by the (lack of) docs produced by `ocm
config --help`, so this commit improves on that by:

- describing how/where we look for the config file;
- printing a table of supported variables with a brief description of
  each;
- adding a reference back to 'ocm config --help' from 'ocm get --help'
  and 'ocm set --help'.

In the future, it would be nice to improve on the help strings
themselves, and deduplicate them with the help strings for the 'ocm
login' flags (whence most of this commit's help strings were stolen).