### PR TITLE
Output Console URL for use in ocm-container

### DIFF
--- a/cmd/ocm/cluster/login/login.go
+++ b/cmd/ocm/cluster/login/login.go
@@ -131,6 +131,8 @@ func run(cmd *cobra.Command, argv []string) error {
 			return fmt.Errorf("Cannot find the console URL for cluster: %s", cluster.Name())
 		}
 
+		fmt.Printf(" Console URL: %s\n", cluster.Console().URL())
+
 		// Open the console url in the broswer, return any errors
 		return browser.OpenURL(cluster.Console().URL())
 	}


### PR DESCRIPTION
https://github.com/drewandersonnz/ocm-container

I want to use OCM outside of my normal environment where browser.OpenURL is not possible.
Specifically I use OCM inside of an ephemeral container where it is isolated from the rest of my host OS.

Outputting the Console URL allows me to copy/paste or simply click the link from within the terminal window.

Accidentally closed https://github.com/openshift-online/ocm-cli/pull/73