### PR TITLE
add --wide option to print console url to the list

### DIFF
--- a/cmd/ocm/account/status/cmd.go
+++ b/cmd/ocm/account/status/cmd.go
@@ -86,8 +86,8 @@ func run(cmd *cobra.Command, argv []string) error {
 	// Display user and which server they are logged into
 	currAccount := response.Body()
 	currOrg := currAccount.Organization()
-	fmt.Println(fmt.Sprintf("User %s on %s in org '%s' %s (external_id: %s)",
-		currAccount.Username(), cfg.URL, currOrg.Name(), currOrg.ID(), currOrg.ExternalID()))
+	fmt.Printf("User %s on %s in org '%s' %s (external_id: %s)",
+		currAccount.Username(), cfg.URL, currOrg.Name(), currOrg.ID(), currOrg.ExternalID())
 
 	// Display roles currently assigned to the user
 	roleSlice, err := acc_util.GetRolesFromUsers([]*amv1.Account{currAccount}, connection)

--- a/cmd/ocm/cluster/list/list.go
+++ b/cmd/ocm/cluster/list/list.go
@@ -40,6 +40,7 @@ var args struct {
 	step      bool
 	columns   string
 	padding   int
+	wide      bool
 }
 
 var managed bool
@@ -80,6 +81,12 @@ func init() {
 		"padding",
 		-1,
 		"Change all column sizes.",
+	)
+	fs.BoolVar(
+		&args.wide,
+		"wide",
+		false,
+		"Print more information",
 	)
 }
 
@@ -125,11 +132,18 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Update our column name and padding variables:
+	paddingByColumn := []int{34, 40, 60, 20}
+
+	// Print console url if wide parameter specified
+	if args.wide {
+		args.columns = "id, name, api.url, console.url, openshift_version, cloud_provider.id, region.id, state"
+		paddingByColumn = []int{34, 40, 60, 84, 20}
+	}
 	args.columns = strings.Replace(args.columns, " ", "", -1)
 	colUpper := strings.ToUpper(args.columns)
 	colUpper = strings.Replace(colUpper, ".", " ", -1)
 	columnNames := strings.Split(colUpper, ",")
-	paddingByColumn := []int{34, 40, 60, 20}
+
 	if args.padding != -1 {
 		if args.padding < 2 {
 			return fmt.Errorf("Padding flag needs to be an integer greater than 2")

--- a/cmd/ocm/cluster/list/list.go
+++ b/cmd/ocm/cluster/list/list.go
@@ -38,12 +38,10 @@ var args struct {
 	header    []string
 	managed   bool
 	step      bool
+	wide      bool
 	columns   string
 	padding   int
-	wide      bool
 }
-
-var managed bool
 
 // Cmd Constant:
 var Cmd = &cobra.Command{
@@ -70,6 +68,12 @@ func init() {
 		false,
 		"Load pages one step at a time",
 	)
+	fs.BoolVar(
+		&args.wide,
+		"wide",
+		false,
+		"Print more information",
+	)
 	fs.StringVar(
 		&args.columns,
 		"columns",
@@ -81,12 +85,6 @@ func init() {
 		"padding",
 		-1,
 		"Change all column sizes.",
-	)
-	fs.BoolVar(
-		&args.wide,
-		"wide",
-		false,
-		"Print more information",
 	)
 }
 
@@ -119,12 +117,6 @@ func run(cmd *cobra.Command, argv []string) error {
 	// Get the client for the resource that manages the collection of clusters:
 	collection := connection.ClustersMgmt().V1().Clusters()
 
-	if cmd.Flags().Changed("managed") {
-		managed = args.managed
-	} else {
-		managed = false
-	}
-
 	// If there is a parameter specified, assume its a filter:
 	var argFilter string
 	if len(argv) == 1 && argv[0] != "" {
@@ -156,6 +148,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	size := 100
 	index := 1
+	managed := args.managed
 	for {
 		// Fetch the next page:
 		request := collection.List().Size(size).Page(index)


### PR DESCRIPTION
For some of the auth providers, people need to login to the cluster via the web console.

To print the console url to the list will be a little convenient if we want to login to multiple clusters.