### PR TITLE
Align cluster commands to other k8s tools

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -1,0 +1,315 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"time"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
+	clusterpkg "github.com/openshift-online/ocm-cli/pkg/cluster"
+	"github.com/openshift-online/ocm-cli/pkg/config"
+)
+
+var args struct {
+	parameter         []string
+	header            []string
+	region            string
+	version           string
+	flavour           string
+	provider          string
+	expirationTime    string
+	expirationSeconds time.Duration
+	private           bool
+}
+
+// Cmd Constant:
+var Cmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Create managed clusters",
+	Long:  "Create managed OpenShift Dedicated v4 clusters via OCM",
+	Args:  cobra.ExactArgs(1),
+	RunE:  run,
+}
+
+func init() {
+	fs := Cmd.Flags()
+	arguments.AddParameterFlag(fs, &args.parameter)
+	arguments.AddHeaderFlag(fs, &args.header)
+	fs.StringVar(
+		&args.region,
+		"region",
+		"us-east-1",
+		"The cloud provider region to create the cluster in",
+	)
+	fs.StringVar(
+		&args.version,
+		"version",
+		"",
+		"The OpenShift version to create the cluster at (for example, \"4.1.16\")",
+	)
+	fs.StringVar(
+		&args.flavour,
+		"flavour",
+		"osd-4",
+		"The OCM flavour to create the cluster with",
+	)
+	fs.StringVar(
+		&args.provider,
+		"provider",
+		"aws",
+		"The cloud provider to create the cluster on",
+	)
+	fs.StringVar(
+		&args.expirationTime,
+		"expiration-time",
+		args.expirationTime,
+		"Specified time when cluster should expire (RFC3339). Only one of expiration-time / expiration may be used.",
+	)
+	fs.DurationVar(
+		&args.expirationSeconds,
+		"expiration",
+		args.expirationSeconds,
+		"Expire cluster after a relative duration like 2h, 8h, 72h. Only one of expiration-time / expiration may be used.",
+	)
+	fs.BoolVar(
+		&args.private,
+		"private",
+		false,
+		"Restrict master API endpoint and application routes to direct, private connectivity.",
+	)
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	var err error
+	var expiration time.Time
+
+	// Validate options
+	if len(args.expirationTime) > 0 && args.expirationSeconds != 0 {
+		return fmt.Errorf("at most one of `expiration-time` or `expiration` may be specified")
+	}
+	if args.region == "us-east-1" && args.provider != "aws" {
+		return fmt.Errorf("if specifying a non-aws cloud provider, region must be set to a valid region")
+	}
+
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("Can't load config file: %v", err)
+	}
+	if cfg == nil {
+		return fmt.Errorf("Not logged in, run the 'login' command")
+	}
+
+	// Check that the configuration has credentials or tokens that haven't have expired:
+	armed, err := cfg.Armed()
+	if err != nil {
+		return fmt.Errorf("Can't check if tokens have expired: %v", err)
+	}
+	if !armed {
+		return fmt.Errorf("Tokens have expired, run the 'login' command")
+	}
+
+	// Create the connection, and remember to close it:
+	connection, err := cfg.Connection()
+	if err != nil {
+		return fmt.Errorf("Can't create connection: %v", err)
+	}
+	defer connection.Close()
+
+	// Get the client for the cluster management api
+	cmv1Client := connection.ClustersMgmt().V1()
+
+	// Check and set the cluster name
+	if len(argv) != 1 || argv[0] == "" {
+		return fmt.Errorf("A cluster name must be specified")
+	}
+	clusterName := argv[0]
+
+	// Parse the expiration options
+	if len(args.expirationTime) > 0 {
+		t, err := parseRFC3339(args.expirationTime)
+		if err != nil {
+			return fmt.Errorf("unable to parse expiration time: %s", err)
+		}
+
+		expiration = t
+	}
+	if args.expirationSeconds != 0 {
+		// round up to the nearest second
+		expiration = time.Now().Add(args.expirationSeconds).Round(time.Second)
+	}
+
+	// Retrieve valid/default versions
+	versionList := sets.NewString()
+	var defaultVersion string
+	versions, err := fetchEnabledVersions(cmv1Client)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve versions: %s", err)
+	}
+	for _, version := range versions {
+		versionList.Insert(version.ID())
+		if version.Default() {
+			defaultVersion = version.ID()
+		}
+	}
+
+	// Check and set the cluster version
+	var clusterVersion string
+	if args.version != "" {
+		if !versionList.Has("openshift-v" + args.version) {
+			return fmt.Errorf("A valid version number must be specified\nValid versions: %+v", versionList.List())
+		}
+		clusterVersion = "openshift-v" + args.version
+	} else {
+		clusterVersion = defaultVersion
+	}
+
+	// Retrieve valid/default flavours
+	flavourList := sets.NewString()
+	flavours, err := fetchFlavours(cmv1Client)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve flavours: %s", err)
+	}
+	for _, flavour := range flavours {
+		flavourList.Insert(flavour.ID())
+	}
+
+	// Check and set the cluster flavour
+	var clusterFlavour string
+	if args.flavour != "" {
+
+		if !flavourList.Has(args.flavour) {
+			return fmt.Errorf("A valid flavour number must be specified\nValid flavours: %+v", flavourList.List())
+		}
+		clusterFlavour = args.flavour
+	}
+
+	clusterBuild := cmv1.NewCluster().
+		Name(clusterName).
+		Flavour(
+			cmv1.NewFlavour().
+				ID(clusterFlavour),
+		).
+		CloudProvider(
+			cmv1.NewCloudProvider().
+				ID(args.provider),
+		).
+		Region(
+			cmv1.NewCloudRegion().
+				ID(args.region),
+		).
+		Version(
+			cmv1.NewVersion().
+				ID(clusterVersion),
+		)
+	if !expiration.IsZero() {
+		clusterBuild = clusterBuild.ExpirationTimestamp(
+			expiration,
+		)
+	}
+	if args.private {
+		clusterBuild = clusterBuild.API(
+			cmv1.NewClusterAPI().
+				Listening(cmv1.ListeningMethodInternal),
+		)
+	} else {
+		clusterBuild = clusterBuild.API(
+			cmv1.NewClusterAPI().
+				Listening(cmv1.ListeningMethodExternal),
+		)
+	}
+	cluster, err := clusterBuild.Build()
+	if err != nil {
+		return fmt.Errorf("unable to build cluster object: %v", err)
+	}
+
+	// Send a request to create the cluster:
+	response, err := cmv1Client.Clusters().Add().
+		Body(cluster).
+		Send()
+	if err != nil {
+		return fmt.Errorf("unable to create cluster: %v", err)
+	}
+
+	// Print the result:
+	cluster = response.Body()
+
+	err = clusterpkg.PrintClusterDesctipion(connection, cluster)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fetchEnabledVersions(client *cmv1.Client) (versions []*cmv1.Version, err error) {
+	collection := client.Versions()
+	page := 1
+	size := 100
+	for {
+		var response *cmv1.VersionsListResponse
+		response, err = collection.List().
+			Search("enabled = 'true'").
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return
+		}
+		versions = append(versions, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+	return
+}
+
+func fetchFlavours(client *cmv1.Client) (flavours []*cmv1.Flavour, err error) {
+	collection := client.Flavours()
+	page := 1
+	size := 100
+	for {
+		var response *cmv1.FlavoursListResponse
+		response, err = collection.List().
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return
+		}
+		flavours = append(flavours, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+	return
+}
+
+// parseRFC3339 parses an RFC3339 date in either RFC3339Nano or RFC3339 format.
+func parseRFC3339(s string) (time.Time, error) {
+	if t, timeErr := time.Parse(time.RFC3339Nano, s); timeErr == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, s)
+}

--- a/cmd/ocm/create/cmd.go
+++ b/cmd/ocm/create/cmd.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/openshift-online/ocm-cli/cmd/ocm/create/cluster"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "create RESOURCE [flags]",
+	Aliases: []string{"add"},
+	Short:   "Create a resource from stdin",
+	Long:    "Create a resource from stdin",
+}
+
+func init() {
+	Cmd.AddCommand(cluster.Cmd)
+}

--- a/cmd/ocm/describe/cluster/cmd.go
+++ b/cmd/ocm/describe/cluster/cmd.go
@@ -1,0 +1,183 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	clusterpkg "github.com/openshift-online/ocm-cli/pkg/cluster"
+	"github.com/openshift-online/ocm-cli/pkg/config"
+	"github.com/openshift-online/ocm-cli/pkg/dump"
+)
+
+var args struct {
+	json   bool
+	output bool
+}
+
+var Cmd = &cobra.Command{
+	Use:   "cluster NAME|ID|EXTERNAL_ID",
+	Short: "Show details of a cluster",
+	Long:  "Show details of a cluster identified by name, identifier or external identifier",
+	RunE:  run,
+}
+
+func init() {
+	// Add flags to rootCmd:
+	flags := Cmd.Flags()
+	flags.BoolVar(
+		&args.output,
+		"output",
+		false,
+		"Output result into JSON file.",
+	)
+	flags.BoolVar(
+		&args.json,
+		"json",
+		false,
+		"Output the entire JSON structure",
+	)
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	// Check that there is exactly one cluster name, identifir or external identifier in the
+	// command line arguments:
+	if len(argv) != 1 {
+		fmt.Fprintf(
+			os.Stderr,
+			"Expected exactly one cluster name, identifier or external identifier "+
+				"is required\n",
+		)
+		os.Exit(1)
+	}
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	key := argv[0]
+	if !keyRE.MatchString(key) {
+		fmt.Fprintf(
+			os.Stderr,
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores\n",
+			key,
+		)
+		os.Exit(1)
+	}
+
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("Can't load config file: %v", err)
+	}
+	if cfg == nil {
+		return fmt.Errorf("Not logged in, run the 'login' command")
+	}
+
+	// Check that the configuration has credentials or tokens that haven't have expired:
+	armed, err := cfg.Armed()
+	if err != nil {
+		return fmt.Errorf("Can't check if tokens have expired: %v", err)
+	}
+	if !armed {
+		return fmt.Errorf("Tokens have expired, run the 'login' command")
+	}
+
+	// Create the connection, and remember to close it:
+	connection, err := cfg.Connection()
+	if err != nil {
+		return fmt.Errorf("Can't create connection: %v", err)
+	}
+	defer connection.Close()
+
+	// Try to find the cluster that has the name, identifier or external identifier matching the
+	// value given by the user:
+	search := fmt.Sprintf("name = '%s' or id = '%s' or external_id = '%s'", key, key, key)
+	response, err := connection.ClustersMgmt().V1().Clusters().List().
+		Search(search).
+		Size(1).
+		Send()
+	if err != nil {
+		return fmt.Errorf("Can't retrieve cluster for key '%s': %v", key, err)
+	}
+	clusters := response.Items().Slice()
+	if len(clusters) == 0 {
+		fmt.Fprintf(
+			os.Stderr,
+			"There is no cluster with name, identifier or external identifier '%s'\n",
+			key,
+		)
+		os.Exit(1)
+	}
+	cluster := clusters[0]
+
+	if args.output {
+		// Create a filename based on cluster name:
+		filename := fmt.Sprintf("cluster-%s.json", cluster.ID())
+
+		// Attempt to create file:
+		myFile, err := os.Create(filename)
+		if err != nil {
+			return fmt.Errorf("Failed to create file: %v", err)
+		}
+
+		// Dump encoder content into file:
+		err = cmv1.MarshalCluster(cluster, myFile)
+		if err != nil {
+			return fmt.Errorf("Failed to Marshal cluster into file: %v", err)
+		}
+	}
+
+	// Get full API response (JSON):
+	if args.json {
+		// Buffer for pretty output:
+		buf := new(bytes.Buffer)
+		fmt.Println()
+
+		// Convert cluster to JSON and dump to encoder:
+		err = cmv1.MarshalCluster(cluster, buf)
+		if err != nil {
+			return fmt.Errorf("Failed to Marshal cluster into JSON encoder: %v", err)
+		}
+
+		if response.Status() < 400 {
+			err = dump.Pretty(os.Stdout, buf.Bytes())
+		} else {
+			err = dump.Pretty(os.Stderr, buf.Bytes())
+		}
+		if err != nil {
+			return fmt.Errorf("Can't print body: %v", err)
+		}
+
+	} else {
+		err = clusterpkg.PrintClusterDesctipion(connection, cluster)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Regular expression to check that the cluster key (name, identifier or external identifier) given
+// by the user is reasonably safe and that there is no risk of SQL injection.
+var keyRE = regexp.MustCompile(`^(\w|-)+$`)

--- a/cmd/ocm/describe/cmd.go
+++ b/cmd/ocm/describe/cmd.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"github.com/openshift-online/ocm-cli/cmd/ocm/describe/cluster"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "describe RESOURCE [flags]",
+	Short: "Show details of a specific resource",
+	Long:  "Show details of a specific resource",
+}
+
+func init() {
+	Cmd.AddCommand(cluster.Cmd)
+}

--- a/cmd/ocm/list/cluster/cmd.go
+++ b/cmd/ocm/list/cluster/cmd.go
@@ -1,0 +1,259 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
+	"github.com/openshift-online/ocm-cli/pkg/config"
+	table "github.com/openshift-online/ocm-cli/pkg/table"
+)
+
+var args struct {
+	parameter []string
+	header    []string
+	managed   bool
+	step      bool
+	columns   string
+	padding   int
+}
+
+// Cmd Constant:
+var Cmd = &cobra.Command{
+	Use:     "clusters [flags] [partial cluster ID or name]",
+	Aliases: []string{"cluster"},
+	Short:   "List clusters",
+	Long:    "List clusters by ID and Name",
+	Args:    cobra.RangeArgs(0, 1),
+	RunE:    run,
+}
+
+func init() {
+	fs := Cmd.Flags()
+	arguments.AddParameterFlag(fs, &args.parameter)
+	arguments.AddHeaderFlag(fs, &args.header)
+	fs.BoolVar(
+		&args.managed,
+		"managed",
+		false,
+		"Filter managed/unmanaged clusters",
+	)
+	fs.BoolVar(
+		&args.step,
+		"step",
+		false,
+		"Load pages one step at a time",
+	)
+	fs.StringVar(
+		&args.columns,
+		"columns",
+		"id, name, api.url, openshift_version, cloud_provider.id, region.id, state",
+		"Specify which columns to display separated by commas, path is based on Cluster struct",
+	)
+	fs.IntVar(
+		&args.padding,
+		"padding",
+		-1,
+		"Change all column sizes.",
+	)
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("Can't load config file: %v", err)
+	}
+	if cfg == nil {
+		return fmt.Errorf("Not logged in, run the 'login' command")
+	}
+
+	// Check that the configuration has credentials or tokens that haven't have expired:
+	armed, err := cfg.Armed()
+	if err != nil {
+		return fmt.Errorf("Can't check if tokens have expired: %v", err)
+	}
+	if !armed {
+		return fmt.Errorf("Tokens have expired, run the 'login' command")
+	}
+
+	// Create the connection, and remember to close it:
+	connection, err := cfg.Connection()
+	if err != nil {
+		return fmt.Errorf("Can't create connection: %v", err)
+	}
+	defer connection.Close()
+
+	// Get the client for the resource that manages the collection of clusters:
+	collection := connection.ClustersMgmt().V1().Clusters()
+
+	// If there is a parameter specified, assume its a filter:
+	var argFilter string
+	if len(argv) == 1 && argv[0] != "" {
+		argFilter = fmt.Sprintf("(name like '%%%s%%' or id like '%%%s%%')", argv[0], argv[0])
+	}
+
+	// Update our column name and padding variables:
+	args.columns = strings.Replace(args.columns, " ", "", -1)
+	colUpper := strings.ToUpper(args.columns)
+	colUpper = strings.Replace(colUpper, ".", " ", -1)
+	columnNames := strings.Split(colUpper, ",")
+	paddingByColumn := []int{34, 40, 60, 20}
+	if args.padding != -1 {
+		if args.padding < 2 {
+			return fmt.Errorf("Padding flag needs to be an integer greater than 2")
+		}
+		paddingByColumn = []int{args.padding}
+	}
+
+	// Print Header Row:
+	table.PrintPadded(os.Stdout, columnNames, paddingByColumn)
+
+	size := 100
+	index := 1
+	for {
+		// Fetch the next page:
+		request := collection.List().Size(size).Page(index)
+		arguments.ApplyParameterFlag(request, args.parameter)
+		arguments.ApplyHeaderFlag(request, args.header)
+		var search strings.Builder
+		if cmd.Flags().Changed("managed") {
+			if search.Len() > 0 {
+				_, err = search.WriteString(" and ")
+				if err != nil {
+					return fmt.Errorf("Can't write to string: %v", err)
+				}
+			}
+			if args.managed {
+				_, err = search.WriteString("managed = 't'")
+			} else {
+				_, err = search.WriteString("managed = 'f'")
+			}
+			if err != nil {
+				return fmt.Errorf("Can't write to string: %v", err)
+			}
+		}
+		if argFilter != "" {
+			if search.Len() > 0 {
+				_, err = search.WriteString(" and ")
+				if err != nil {
+					return fmt.Errorf("Can't write to string: %v", err)
+				}
+			}
+			_, err = search.WriteString(argFilter)
+			if err != nil {
+				return fmt.Errorf("Can't write to string: %v", err)
+			}
+		}
+		request.Search(strings.TrimSpace(search.String()))
+		response, err := request.Send()
+		if err != nil {
+			return fmt.Errorf("Can't retrieve clusters: %v", err)
+		}
+
+		// Display the fetched page:
+		response.Items().Each(func(cluster *v1.Cluster) bool {
+
+			// String to output marshal -
+			// Map used to parse Cluster data -
+			// Writer to body variable:
+			var body string
+			var jsonBody map[string]interface{}
+			boddyBuffer := bytes.NewBufferString(body)
+
+			// Write Cluster data to body variable:
+			err := v1.MarshalCluster(cluster, boddyBuffer)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to marshal cluster into byte buffer: %s\n", err)
+				os.Exit(1)
+			}
+
+			// Get JSON from Cluster bytes:
+			err = json.Unmarshal(boddyBuffer.Bytes(), &jsonBody)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to turn cluster bytes into JSON map: %s\n", err)
+				os.Exit(1)
+			}
+
+			// Loop through wanted columns and populate a cluster instance:
+			iter := strings.Split(args.columns, ",")
+			thisCluster := []string{}
+			for _, element := range iter {
+				value, status := table.FindMapValue(jsonBody, element)
+				if !status {
+					value = "NONE"
+				}
+				thisCluster = append(thisCluster, value)
+			}
+			table.PrintPadded(os.Stdout, thisCluster, paddingByColumn)
+			return true
+
+		})
+
+		// if step was flagged, load only one page at a time:
+		if args.step {
+			if response.Size() < size {
+				break
+			}
+			fmt.Println()
+			fmt.Println("Press the 'Enter' to load more:")
+			_, err := bufio.NewReader(os.Stdin).ReadBytes('\n')
+			// var input string
+			if err != nil {
+				return fmt.Errorf("Failed to retrieve input: %v", err)
+			}
+			err = clearPage()
+			if err != nil {
+				return fmt.Errorf("Failed to clear page: %v", err)
+			}
+			table.PrintPadded(os.Stdout, columnNames, paddingByColumn)
+			fmt.Println()
+		}
+
+		// If the number of fetched results is less than requested, then
+		// this was the last page, otherwise process the next one:
+		if response.Size() < size {
+			break
+		}
+		index++
+	}
+
+	return nil
+}
+
+// clearPage clears the page.
+func clearPage() error {
+	// #nosec 204
+	cmd := exec.Command("clear")
+	cmd.Stdout = os.Stdout
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/ocm/list/cmd.go
+++ b/cmd/ocm/list/cmd.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"github.com/openshift-online/ocm-cli/cmd/ocm/list/cluster"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "list RESOURCE",
+	Short: "List all resources of a specific type",
+	Long:  "List all resources of a specific type",
+}
+
+func init() {
+	Cmd.AddCommand(cluster.Cmd)
+}

--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift-online/ocm-cli/cmd/ocm/delete"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/describe"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/get"
+	"github.com/openshift-online/ocm-cli/cmd/ocm/list"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/login"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/logout"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/patch"
@@ -68,6 +69,7 @@ func init() {
 	root.AddCommand(delete.Cmd)
 	root.AddCommand(describe.Cmd)
 	root.AddCommand(get.Cmd)
+	root.AddCommand(list.Cmd)
 	root.AddCommand(login.Cmd)
 	root.AddCommand(logout.Cmd)
 	root.AddCommand(patch.Cmd)

--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift-online/ocm-cli/cmd/ocm/completion"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/config"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/delete"
+	"github.com/openshift-online/ocm-cli/cmd/ocm/describe"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/get"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/login"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/logout"
@@ -65,6 +66,7 @@ func init() {
 	// Register the subcommands:
 	root.AddCommand(account.Cmd)
 	root.AddCommand(delete.Cmd)
+	root.AddCommand(describe.Cmd)
 	root.AddCommand(get.Cmd)
 	root.AddCommand(login.Cmd)
 	root.AddCommand(logout.Cmd)

--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift-online/ocm-cli/cmd/ocm/cluster"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/completion"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/config"
+	"github.com/openshift-online/ocm-cli/cmd/ocm/create"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/delete"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/describe"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/get"
@@ -66,6 +67,7 @@ func init() {
 
 	// Register the subcommands:
 	root.AddCommand(account.Cmd)
+	root.AddCommand(create.Cmd)
 	root.AddCommand(delete.Cmd)
 	root.AddCommand(describe.Cmd)
 	root.AddCommand(get.Cmd)


### PR DESCRIPTION
Added describe, list and create cluster commands.
This is the first part of changing `ocm-cli` commands to align with other k8s tools.