### PR TITLE
Release 0.1.38

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,19 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+== 0.1.38 Jun 13 2020
+
+- Add support for expiration in ocm cluster create.
+- Add support for specifying cloud provider.
+- Add cloud provider to default columns.
+- config: beef up help message.
+- Add console URL to describe.
+- Output Console URL.
+- Add shell completion for resources.
+- Add API Listening to cluster descrribe.
+- Update to ocm-sdk-go 0.1.105
+- Allow setting --managed=false in cluster list.
+
 == 0.1.37 Feb 26 2020
 
 - Describe by name, identifier or external identifier (fixes

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.37"
+const Version = "0.1.38"


### PR DESCRIPTION
The more relevant changes in the new release are the following:

- Add support for expiration in ocm cluster create.
- Add support for specifying cloud provider.
- Add cloud provider to default columns.
- config: beef up help message.
- Add console URL to describe.
- Output Console URL.
- Add shell completion for resources.
- Add API Listening to cluster descrribe.
- Update to ocm-sdk-go 0.1.105
- Allow setting --managed=false in cluster list.