### PR TITLE
curl follows redirects to download the binary

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ the following commands:
 
 ....
 $ mkdir -p ~/bin
-$ curl -o ~/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.30/ocm-linux-amd64
+$ curl -Lo ~/bin/ocm https://github.com/openshift-online/ocm-cli/releases/download/v0.1.30/ocm-linux-amd64
 $ chmod +x ~/bin/ocm
 ....
 


### PR DESCRIPTION
The currently documented curl command returns a 302:

```
$ curl -sI https://github.com/openshift-online/ocm-cli/releases/download/v0.1.30/ocm-linux-amd64|grep ^status
status: 302 Found
```