### PR TITLE
Output sshuttle command execution string for review

### DIFF
--- a/cmd/ocm/tunnel/cmd.go
+++ b/cmd/ocm/tunnel/cmd.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
@@ -103,6 +104,9 @@ func run(cmd *cobra.Command, argv []string) error {
 		cluster.Network().PodCIDR(),
 	}
 	sshuttleArgs = append(sshuttleArgs, argv[0:]...)
+
+	// Output sshuttle command execution string for review
+	fmt.Printf("\n# %s %s\n\n", path, strings.Join(sshuttleArgs, " "))
 
 	// #nosec G204
 	sshuttleCmd := exec.Command(path, sshuttleArgs...)


### PR DESCRIPTION
This command parameters change for every cluster, however I have a need to transfer the `sshuttle` execution out of my tool `ocm-container` https://github.com/drewandersonnz/ocm-container where `ocm` lives within ephemeral containers.
 
Example:

```
ocm tunnel -c xzy123
Will create tunnel to cluster:
 Name: cluster
 ID: xyz123

# /usr/bin/sshuttle --remote sre-user@xyz123.example.com 10.0.0.0/16 172.30.0.0/16 10.128.0.0/14

client: Connected.
```