### PR TITLE
doc(login.sh): add printf before login

### DIFF
--- a/cmd/ocm/cluster/login/login.go
+++ b/cmd/ocm/cluster/login/login.go
@@ -129,6 +129,8 @@ func run(cmd *cobra.Command, argv []string) error {
 		// Create token url from console URL and open browser
 		loginURL := strings.Replace(cluster.Console().URL(), "console-openshift-console", "oauth-openshift", 1)
 		loginURL += "/oauth/token/request"
+		fmt.Printf(" Login URL: %s\n", loginURL)
+		
 		return browser.OpenURL(loginURL)
 	}
 

--- a/cmd/ocm/cluster/login/login.go
+++ b/cmd/ocm/cluster/login/login.go
@@ -130,7 +130,6 @@ func run(cmd *cobra.Command, argv []string) error {
 		loginURL := strings.Replace(cluster.Console().URL(), "console-openshift-console", "oauth-openshift", 1)
 		loginURL += "/oauth/token/request"
 		fmt.Printf(" Login URL: %s\n", loginURL)
-		
 		return browser.OpenURL(loginURL)
 	}
 


### PR DESCRIPTION
this is useful if you are running inside a container without browser access and want that url for external login