### PR TITLE
Show hint when waiting for body from stdin interactively

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/mattn/go-isatty v0.0.8
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -19,13 +19,15 @@ limitations under the License.
 package arguments
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"os"
 	"reflect"
 	"strings"
 
-	"github.com/openshift-online/ocm-sdk-go"
+	"github.com/mattn/go-isatty"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/spf13/pflag"
 
 	"github.com/openshift-online/ocm-cli/pkg/debug"
@@ -121,6 +123,9 @@ func ApplyBodyFlag(request *sdk.Request, value string) error {
 		// #nosec G304
 		body, err = ioutil.ReadFile(value)
 	} else {
+		if isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stderr.Fd()) {
+			fmt.Fprintln(os.Stderr, "No --body file specified, reading request body from stdin:")
+		}
 		body, err = ioutil.ReadAll(os.Stdin)
 	}
 	if err != nil {


### PR DESCRIPTION
https://issues.redhat.com/browse/SDA-2723

This addresses the usability problem that when using `post` or `patch` and one forgets a body is needed, the command just appears to hang (as it's waiting for input and EOF).  Now it'll print a message to stderr explaining what happens and why:
<pre>
<b>$ ./ocm post /api/authorizations/v1/self_access_review | jq .</b>
No --body file specified, reading request body from stdin:
<b>{"resource_type": "Subscription", "action": "get"}</b>
<kbd><b>Ctrl+D</b></kbd>
{
  "account_id": "1Du28axTYfDk2r9fHOUGSoo5GZa",
  "resource_type": "Subscription",
  "action": "get",
  "allowed": true
}
</pre>

Composing JSON on stdin is not really convenient; typically one would send it by redirection / pipe.
In these cases we don't print the message:
```sh
$ echo '{"resource_type": "Subscription", "action": "get"}' | ./ocm post /api/authorizations/v1/self_access_review | jq .
{
  "account_id": "1Du28axTYfDk2r9fHOUGSoo5GZa",
  "resource_type": "Subscription",
  "action": "get",
  "allowed": true
}
$ ./ocm post /api/authorizations/v1/self_access_review < in.yaml | jq .
{
  "account_id": "1Du28axTYfDk2r9fHOUGSoo5GZa",
  "resource_type": "Subscription",
  "action": "get",
  "allowed": true
}
$ ./ocm post /api/authorizations/v1/self_access_review --body=in.yaml | jq .
{
  "account_id": "1Du28axTYfDk2r9fHOUGSoo5GZa",
  "resource_type": "Subscription",
  "action": "get",
  "allowed": true
}
```
nor if stderr is redirected, as user wouldn't see it anyway:
```
$ ./ocm post /api/authorizations/v1/self_access_review 2>err | jq .
{"resource_type": "Subscription", "action": "get"}
{
  "account_id": "1Du28axTYfDk2r9fHOUGSoo5GZa",
  "resource_type": "Subscription",
  "action": "get",
  "allowed": true
}
$ cat err
$
```

(piping to `| jq .` in above examples demonstrates that stdout is unaffected in all cases)