### PR TITLE
use the cluster id directly without --cluster

### DIFF
--- a/cmd/ocm/tunnel/cmd.go
+++ b/cmd/ocm/tunnel/cmd.go
@@ -29,10 +29,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var args struct {
-	clusterKey string
-}
-
 var Cmd = &cobra.Command{
 	Use:   "tunnel <CLUSTERID|CLUSTER_NAME|CLUSTER_NAME_SEARCH> -- [sshuttle arguments]",
 	Short: "tunnel to a cluster",


### PR DESCRIPTION
if the cluster id is the only parameter for the command, I think it is better to pass the cluster_id directly without `--cluster` for easy use.

@cblecker Please help take a look.