### PR TITLE
Use correct implementation for `ocm list version`

### DIFF
--- a/cmd/ocm/list/cmd.go
+++ b/cmd/ocm/list/cmd.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift-online/ocm-cli/cmd/ocm/list/idp"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/list/ingress"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/list/user"
-	"github.com/openshift-online/ocm-cli/cmd/ocm/version"
+	"github.com/openshift-online/ocm-cli/cmd/ocm/list/version"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ocm/list/version/cmd.go
+++ b/cmd/ocm/list/version/cmd.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package versions
+package version
 
 import (
 	"fmt"
@@ -27,9 +27,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "versions",
-	Short: "List available versions",
-	Long:  "List the versions available for provisioning a cluster",
+	Use:     "versions",
+	Aliases: []string{"version"},
+	Short:   "List available versions",
+	Long:    "List the versions available for provisioning a cluster",
 	Example: `  # List all supported cluster versions
   ocm list versions`,
 	RunE: run,


### PR DESCRIPTION
@igoihman tiny fix, please review.

Followup to #152.  Wrong import caused it to offer:

    $ ./ocm list --help
    ...
      version     Prints the version


    $ ./ocm list version
    0.1.43

now does:

    $ ./ocm list --help
    ...
      versions    List available versions

    $ ./ocm list versions
    4.3.25
    4.4.11
    ...

    $ ./ocm list version
    4.3.25
    4.4.11
    ...

Added list version = list versions alias and changed package name to singular for consistency with sibling commands.
