### PR TITLE
Improve help and positional arg enforcement in most commands

### DIFF
--- a/cmd/ocm/account/orgs/cmd.go
+++ b/cmd/ocm/account/orgs/cmd.go
@@ -42,6 +42,7 @@ var Cmd = &cobra.Command{
 	Use:   "orgs",
 	Short: "List organizations.",
 	Long:  "Display a list of organizations.",
+	Args:  cobra.NoArgs,
 	RunE:  run,
 }
 

--- a/cmd/ocm/account/quota/cmd.go
+++ b/cmd/ocm/account/quota/cmd.go
@@ -37,6 +37,7 @@ var Cmd = &cobra.Command{
 	Use:   "quota",
 	Short: "Retrieve cluster quota information.",
 	Long:  "Retrieve cluster quota information of a specific organization.",
+	Args:  cobra.NoArgs,
 	RunE:  run,
 }
 

--- a/cmd/ocm/account/roles/cmd.go
+++ b/cmd/ocm/account/roles/cmd.go
@@ -32,10 +32,16 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "roles [role-name]",
+	Use:   "roles [flags] [ROLE_NAME]",
 	Short: "Retrieve information of the different roles",
-	Long:  "Get description of a role or list of all roles ",
-	RunE:  run,
+	Long:  "Get description of a role or list of all roles",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			return fmt.Errorf("Accepts at most 1 role name")
+		}
+		return nil
+	},
+	RunE: run,
 }
 
 func init() {

--- a/cmd/ocm/account/status/cmd.go
+++ b/cmd/ocm/account/status/cmd.go
@@ -35,6 +35,7 @@ var Cmd = &cobra.Command{
 	Use:   "status",
 	Short: "Status of current user.",
 	Long:  "Display status of current user.",
+	Args:  cobra.NoArgs,
 	RunE:  run,
 }
 

--- a/cmd/ocm/account/users/cmd.go
+++ b/cmd/ocm/account/users/cmd.go
@@ -39,6 +39,7 @@ var Cmd = &cobra.Command{
 	Use:   "users",
 	Short: "Retrieve users and their roles",
 	Long:  "Retrieve information of all users/roles in the same organization",
+	Args:  cobra.NoArgs,
 	RunE:  run,
 }
 

--- a/cmd/ocm/cluster/create/create.go
+++ b/cmd/ocm/cluster/create/create.go
@@ -43,7 +43,7 @@ var args struct {
 
 // Cmd Constant:
 var Cmd = &cobra.Command{
-	Use:        "create [flags] <cluster name>",
+	Use:        "create [flags] CLUSTER_NAME",
 	Short:      "Create managed clusters",
 	Long:       "Create managed OpenShift Dedicated v4 clusters via OCM",
 	Deprecated: "please use `ocm create cluster` command",

--- a/cmd/ocm/cluster/describe/describe.go
+++ b/cmd/ocm/cluster/describe/describe.go
@@ -36,7 +36,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:        "describe NAME|ID|EXTERNAL_ID [--output] [--short]",
+	Use:        "describe [flags] {NAME|ID|EXTERNAL_ID}",
 	Short:      "Describe a cluster",
 	Long:       "Get info about a cluster identified by name, identifier or external identifier",
 	Deprecated: "please use `ocm describe cluster` command",

--- a/cmd/ocm/cluster/list/list.go
+++ b/cmd/ocm/cluster/list/list.go
@@ -44,9 +44,9 @@ var args struct {
 
 // Cmd Constant:
 var Cmd = &cobra.Command{
-	Use:        "list [flags] [partial cluster ID or name]",
+	Use:        "list [flags] [PARTIAL_CLUSTER_ID_OR_NAME]",
 	Short:      "List clusters",
-	Long:       "List clusters by ID and Name",
+	Long:       "List clusters, optionally filtering by substring of ID or Name",
 	Deprecated: "please use `ocm list clusters` command",
 	Args:       cobra.RangeArgs(0, 1),
 	RunE:       run,

--- a/cmd/ocm/cluster/login/login.go
+++ b/cmd/ocm/cluster/login/login.go
@@ -35,14 +35,14 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "login [CLUSTERID|CLUSTER_NAME|CLUSTER_NAME_SEARCH]",
+	Use:   "login [flags] {CLUSTER_ID|CLUSTER_NAME|CLUSTER_NAME_SEARCH}",
 	Short: "login to a cluster",
 	Long: "login to a cluster by ID or Name or cluster name search string according to the api: " +
 		"https://api.openshift.com/#/clusters/get_api_clusters_mgmt_v1_clusters",
 	Example: " ocm cluster login <id>\n ocm cluster login %test%",
 	RunE:    run,
 	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
+		if len(args) != 1 {
 			return fmt.Errorf("cluster name expected")
 		}
 

--- a/cmd/ocm/cluster/status/status.go
+++ b/cmd/ocm/cluster/status/status.go
@@ -24,7 +24,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "status CLUSTERID",
+	Use:   "status [flags] CLUSTER_ID",
 	Short: "Status of a cluster",
 	Long:  "Get the status of a cluster identified by its cluster ID",
 	RunE:  run,
@@ -33,7 +33,7 @@ var Cmd = &cobra.Command{
 func run(cmd *cobra.Command, argv []string) error {
 
 	if len(argv) != 1 {
-		return fmt.Errorf("Expected exactly one cluster")
+		return fmt.Errorf("Expected exactly one cluster id")
 	}
 
 	// Create the client for the OCM API:

--- a/cmd/ocm/cluster/versions/versions.go
+++ b/cmd/ocm/cluster/versions/versions.go
@@ -31,15 +31,11 @@ var Cmd = &cobra.Command{
 	Short:      "List available versions",
 	Long:       "List the versions available for provisioning a cluster",
 	Deprecated: "please use `ocm list versions` command",
+	Args:       cobra.NoArgs,
 	RunE:       run,
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-
-	if len(argv) != 0 {
-		return fmt.Errorf("Expected no arguments")
-	}
-
 	// Create the client for the OCM API:
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {

--- a/cmd/ocm/completion/cmd.go
+++ b/cmd/ocm/completion/cmd.go
@@ -35,6 +35,7 @@ To configure your bash shell to load completions for each session add to your ba
 # ~/.bashrc or ~/.profile
 . <(ocm completion)
 `,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 

--- a/cmd/ocm/config/cmd.go
+++ b/cmd/ocm/config/cmd.go
@@ -56,7 +56,11 @@ or ~/.ocm.json if that variable is unset. Currently using: %s
 
 The following variables are supported:
 
-%s`, loc, configVarDocs())
+%s
+
+Note that "ocm config get access_token" gives whatever the file contains - may be missing or expired;
+you probably want "ocm token" command instead which will obtain a fresh token if needed.
+`, loc, configVarDocs())
 	return
 }
 

--- a/cmd/ocm/config/get/get.go
+++ b/cmd/ocm/config/get/get.go
@@ -30,10 +30,10 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "get VARIABLE",
+	Use:   "get [flags] VARIABLE",
 	Short: "Prints the value of a config variable",
 	Long:  "Prints the value of a config variable. See 'ocm config --help' for supported config variables.",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	RunE:  run,
 }
 
@@ -76,7 +76,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	case "url":
 		fmt.Fprintf(os.Stdout, "%s\n", cfg.URL)
 	default:
-		fmt.Fprintf(os.Stderr, "Uknown setting\n")
+		return fmt.Errorf("Unknown setting")
 	}
 
 	return nil

--- a/cmd/ocm/config/set/set.go
+++ b/cmd/ocm/config/set/set.go
@@ -30,10 +30,10 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "set VARIABLE VALUE",
+	Use:   "set [flags] VARIABLE VALUE",
 	Short: "Sets the variable's value",
 	Long:  "Sets the value of a config variable. See 'ocm config --help' for supported config variables.",
-	Args:  cobra.MinimumNArgs(2),
+	Args:  cobra.ExactArgs(2),
 	RunE:  run,
 }
 

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -59,11 +59,12 @@ var args struct {
 
 // Cmd Constant:
 var Cmd = &cobra.Command{
-	Use:   "cluster",
+	Use:   "cluster [flags] NAME",
 	Short: "Create managed clusters",
-	Long:  "Create managed OpenShift Dedicated v4 clusters via OCM",
-	Args:  cobra.ExactArgs(1),
-	RunE:  run,
+	Long: "Create managed OpenShift Dedicated v4 clusters via OCM.\n" +
+		"\n" +
+		"The specified name is used as a DNS component, as well as initial display_name.",
+	RunE: run,
 }
 
 func init() {

--- a/cmd/ocm/create/cmd.go
+++ b/cmd/ocm/create/cmd.go
@@ -23,7 +23,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "create RESOURCE [flags]",
+	Use:     "create [flags] RESOURCE",
 	Aliases: []string{"add"},
 	Short:   "Create a resource from stdin",
 	Long:    "Create a resource from stdin",

--- a/cmd/ocm/create/idp/cmd.go
+++ b/cmd/ocm/create/idp/cmd.go
@@ -62,13 +62,14 @@ var args struct {
 var validIdps = []string{"github", "google", "ldap", "openid"}
 
 var Cmd = &cobra.Command{
-	Use:   "idp",
+	Use:   "idp --cluster={NAME|ID|EXTERNAL_ID}",
 	Short: "Add IDP for cluster",
 	Long:  "Add an Identity providers to determine how users log into the cluster.",
 	Example: `  # Add a GitHub identity provider to a cluster named "mycluster"
   ocm create idp --type=github --cluster=mycluster
   # Add an identity provider following interactive prompts
   ocm create idp --cluster=mycluster`,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 

--- a/cmd/ocm/create/idp/cmd.go
+++ b/cmd/ocm/create/idp/cmd.go
@@ -82,7 +82,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to add the IdP to (required).",
+		"Name or ID or external_id of the cluster to add the IdP to (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/create/ingress/cmd.go
+++ b/cmd/ocm/create/ingress/cmd.go
@@ -52,7 +52,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to add the ingress to (required).",
+		"Name or ID or external_id of the cluster to add the ingress to (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/create/ingress/cmd.go
+++ b/cmd/ocm/create/ingress/cmd.go
@@ -30,7 +30,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "ingress",
+	Use:     "ingress --cluster={NAME|ID|EXTERNAL_ID}",
 	Aliases: []string{"route", "routes", "ingresses"},
 	Short:   "Add Ingress to cluster",
 	Long:    "Add an Ingress endpoint to determine API access to the cluster.",
@@ -40,6 +40,7 @@ var Cmd = &cobra.Command{
   ocm create ingress --cluster=mycluster
   # Add an ingress with route selector label match
   ocm create ingress -c mycluster --label-match="foo=bar,bar=baz"`,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 

--- a/cmd/ocm/create/machinepool/cmd.go
+++ b/cmd/ocm/create/machinepool/cmd.go
@@ -31,7 +31,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "machinepool",
+	Use:     "machinepool --cluster={NAME|ID|EXTERNAL_ID} --replicas=N [flags] MACHINE_POOL_ID",
 	Aliases: []string{"machinepools", "machine-pool", "machine-pools"},
 	Short:   "Add machine pool to cluster",
 	Long:    "Add a machine pool to the cluster.",

--- a/cmd/ocm/create/machinepool/cmd.go
+++ b/cmd/ocm/create/machinepool/cmd.go
@@ -52,7 +52,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to add the machine pool to (required).",
+		"Name or ID or external_id of the cluster to add the machine pool to (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/create/user/cmd.go
+++ b/cmd/ocm/create/user/cmd.go
@@ -47,7 +47,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to add the user to (required).",
+		"Name or ID or external_id of the cluster to add the user to (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/create/user/cmd.go
+++ b/cmd/ocm/create/user/cmd.go
@@ -30,11 +30,11 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "user",
+	Use:     "user --cluster={NAME|ID|EXTERNAL_ID} --group=GROUP_ID [flags] USERS",
 	Aliases: []string{"users"},
 	Short:   "Configure user access for cluster",
-	Long:    "Configure user access for cluster",
-	Example: `# Add users to the dedicated-admins group
+	Long:    "Add users (comma-separated) to a priviledged group on a cluster.",
+	Example: `  # Add users to the dedicated-admins group
   ocm create user user1,user2 --cluster=mycluster --group=dedicated-admins`,
 	RunE: run,
 }
@@ -56,7 +56,7 @@ func init() {
 		&args.group,
 		"group",
 		"",
-		"Group name to add the users to.",
+		"Group name to add the users to (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("group")

--- a/cmd/ocm/delete/cmd.go
+++ b/cmd/ocm/delete/cmd.go
@@ -39,7 +39,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:       "delete PATH",
+	Use:       "delete [flags] PATH",
 	Short:     "Send a DELETE request",
 	Long:      "Send a DELETE request to the given path.",
 	RunE:      run,

--- a/cmd/ocm/delete/idp/cmd.go
+++ b/cmd/ocm/delete/idp/cmd.go
@@ -28,7 +28,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "idp [IDP NAME]",
+	Use:     "idp --cluster={NAME|ID|EXTERNAL_ID} [flags] IDP_NAME",
 	Aliases: []string{"idps"},
 	Short:   "Delete cluster IDPs",
 	Long:    "Delete a specific identity provider for a cluster.",

--- a/cmd/ocm/delete/idp/cmd.go
+++ b/cmd/ocm/delete/idp/cmd.go
@@ -45,7 +45,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to delete the IdP from (required).",
+		"Name or ID or external_id of the cluster to delete the IdP from (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/delete/ingress/cmd.go
+++ b/cmd/ocm/delete/ingress/cmd.go
@@ -49,7 +49,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to delete the ingress from (required).",
+		"Name or ID or external_id of the cluster to delete the ingress from (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/delete/ingress/cmd.go
+++ b/cmd/ocm/delete/ingress/cmd.go
@@ -30,7 +30,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "ingress",
+	Use:     "ingress --cluster={NAME|ID|EXTERNAL_ID} [flags] INGRESS_ID",
 	Aliases: []string{"ingresses", "route", "routes"},
 	Short:   "Delete cluster ingress",
 	Long:    "Delete the additional non-default application router for a cluster.",

--- a/cmd/ocm/delete/machinepool/cmd.go
+++ b/cmd/ocm/delete/machinepool/cmd.go
@@ -27,7 +27,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "machinepool",
+	Use:     "machinepool --cluster={NAME|ID|EXTERNAL_ID} [flags] MACHINE_POOL_ID",
 	Aliases: []string{"machine-pool", "machinepools", "machine-pools"},
 	Short:   "Delete cluster machine pool",
 	Long:    "Delete the additional machine pool of a cluster.",

--- a/cmd/ocm/delete/machinepool/cmd.go
+++ b/cmd/ocm/delete/machinepool/cmd.go
@@ -44,7 +44,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to delete the machine pool from (required).",
+		"Name or ID or external_id of the cluster to delete the machine pool from (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/delete/user/cmd.go
+++ b/cmd/ocm/delete/user/cmd.go
@@ -28,10 +28,10 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "user",
+	Use:     "user --cluster={NAME|ID|EXTERNAL_ID} --group=GROUP_ID [flags] USER1",
 	Aliases: []string{"users"},
 	Short:   "Remove user access from cluster",
-	Long:    "Remove user access from cluster",
+	Long:    "Remove a user from a priviledged group on a cluster.",
 	Example: `# Delete users from the dedicated-admins group
   ocm delete user user1 --cluster=mycluster --group=dedicated-admins`,
 	RunE: run,

--- a/cmd/ocm/delete/user/cmd.go
+++ b/cmd/ocm/delete/user/cmd.go
@@ -45,7 +45,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to delete the user from (required).",
+		"Name or ID or external_id of the cluster to delete the user from (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/describe/cluster/cmd.go
+++ b/cmd/ocm/describe/cluster/cmd.go
@@ -36,7 +36,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "cluster NAME|ID|EXTERNAL_ID",
+	Use:   "cluster [flags] {NAME|ID|EXTERNAL_ID}",
 	Short: "Show details of a cluster",
 	Long:  "Show details of a cluster identified by name, identifier or external identifier",
 	RunE:  run,

--- a/cmd/ocm/describe/cmd.go
+++ b/cmd/ocm/describe/cmd.go
@@ -19,7 +19,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "describe RESOURCE [flags]",
+	Use:   "describe [flags] RESOURCE",
 	Short: "Show details of a specific resource",
 	Long:  "Show details of a specific resource",
 }

--- a/cmd/ocm/edit/cluster/cmd.go
+++ b/cmd/ocm/edit/cluster/cmd.go
@@ -38,11 +38,12 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "cluster",
+	Use:   "cluster --cluster={NAME|ID|EXTERNAL_ID}",
 	Short: "Edit cluster",
 	Long:  "Edit cluster.",
 	Example: `  # Edit a cluster named "mycluster" to make it private
   ocm edit cluster mycluster --private`,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 
@@ -54,7 +55,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster.",
+		"Name or ID or external_id of the cluster.",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/edit/ingress/cmd.go
+++ b/cmd/ocm/edit/ingress/cmd.go
@@ -52,7 +52,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to add the ingress to (required).",
+		"Name or ID or external_id of the cluster to add the ingress to (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/edit/ingress/cmd.go
+++ b/cmd/ocm/edit/ingress/cmd.go
@@ -33,7 +33,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "ingress",
+	Use:     "ingress --cluster={NAME|ID|EXTERNAL_ID} [flags] INGRESS_ID",
 	Aliases: []string{"route", "routes", "ingresses"},
 	Short:   "Edit a cluster Ingress",
 	Long:    "Edit an Ingress endpoint to determine access to the cluster.",

--- a/cmd/ocm/edit/machinepool/cmd.go
+++ b/cmd/ocm/edit/machinepool/cmd.go
@@ -28,7 +28,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "machinepool",
+	Use:     "machinepool --cluster={NAME|ID|EXTERNAL_ID} [flags] MACHINE_POOL_ID",
 	Aliases: []string{"machine-pool"},
 	Short:   "Edit a cluster machine pool",
 	Long:    "Edit a machine pool size.",

--- a/cmd/ocm/edit/machinepool/cmd.go
+++ b/cmd/ocm/edit/machinepool/cmd.go
@@ -45,7 +45,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to edit the machine pool (required).",
+		"Name or ID or external_id of the cluster to edit the machine pool (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/get/cmd.go
+++ b/cmd/ocm/get/cmd.go
@@ -35,7 +35,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:       "get RESOURCE {ID}",
+	Use:       "get RESOURCE [ID]",
 	Short:     "Send a GET request",
 	Long:      "Send a GET request to the given path.",
 	RunE:      run,

--- a/cmd/ocm/list/addon/cmd.go
+++ b/cmd/ocm/list/addon/cmd.go
@@ -30,12 +30,13 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "addons",
+	Use:     "addons --cluster={NAME|ID|EXTERNAL_ID}",
 	Aliases: []string{"addon", "add-ons", "add-on"},
 	Short:   "List add-on installations",
 	Long:    "List add-ons installed on a cluster.",
 	Example: `  # List all add-on installations on a cluster named "mycluster"
   ocm list addons --cluster=mycluster`,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 

--- a/cmd/ocm/list/addon/cmd.go
+++ b/cmd/ocm/list/addon/cmd.go
@@ -48,7 +48,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to list the add-ons of (required).",
+		"Name or ID or external_id of the cluster to list the add-ons of (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/list/cluster/cmd.go
+++ b/cmd/ocm/list/cluster/cmd.go
@@ -44,10 +44,10 @@ var args struct {
 
 // Cmd Constant:
 var Cmd = &cobra.Command{
-	Use:     "clusters [flags] [partial cluster ID or name]",
+	Use:     "clusters [flags] [PARTIAL_CLUSTER_ID_OR_NAME]",
 	Aliases: []string{"cluster"},
 	Short:   "List clusters",
-	Long:    "List clusters by ID and Name",
+	Long:    "List clusters, optionally filtering by substring of ID or Name",
 	Args:    cobra.RangeArgs(0, 1),
 	RunE:    run,
 }

--- a/cmd/ocm/list/idp/cmd.go
+++ b/cmd/ocm/list/idp/cmd.go
@@ -48,7 +48,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to list the IdP of (required).",
+		"Name or ID or external_id of the cluster to list the IdP of (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/list/idp/cmd.go
+++ b/cmd/ocm/list/idp/cmd.go
@@ -30,12 +30,13 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "idps",
+	Use:     "idps --cluster={NAME|ID|EXTERNAL_ID}",
 	Aliases: []string{"idp"},
 	Short:   "List cluster IDPs",
 	Long:    "List identity providers for a cluster.",
 	Example: `  # List all identity providers on a cluster named "mycluster"
   ocm list idps --cluster=mycluster`,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 

--- a/cmd/ocm/list/ingress/cmd.go
+++ b/cmd/ocm/list/ingress/cmd.go
@@ -52,7 +52,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to list the routes of (required).",
+		"Name or ID or external_id of the cluster to list the routes of (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/list/ingress/cmd.go
+++ b/cmd/ocm/list/ingress/cmd.go
@@ -34,12 +34,13 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "ingresses",
+	Use:     "ingresses --cluster={NAME|ID|EXTERNAL_ID}",
 	Aliases: []string{"route", "routes", "ingress"},
 	Short:   "List cluster Ingresses",
 	Long:    "List API and ingress endpoints for a cluster.",
 	Example: `  # List all routes on a cluster named "mycluster"
   ocm list ingresses --cluster=mycluster`,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 

--- a/cmd/ocm/list/machinepool/cmd.go
+++ b/cmd/ocm/list/machinepool/cmd.go
@@ -52,7 +52,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to list the machine pools of (required).",
+		"Name or ID or external_id of the cluster to list the machine pools of (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/list/machinepool/cmd.go
+++ b/cmd/ocm/list/machinepool/cmd.go
@@ -34,7 +34,7 @@ var args struct {
 }
 
 var Cmd = &cobra.Command{
-	Use:     "machinepools",
+	Use:     "machinepools --cluster={NAME|ID|EXTERNAL_ID}",
 	Aliases: []string{"machine-pool", "machine-pools", "machinepool"},
 	Short:   "List cluster machine pools",
 	Long:    "List machine pools for a cluster.",

--- a/cmd/ocm/list/machinepool/cmd.go
+++ b/cmd/ocm/list/machinepool/cmd.go
@@ -40,6 +40,7 @@ var Cmd = &cobra.Command{
 	Long:    "List machine pools for a cluster.",
 	Example: `  # List all machine pools on a cluster named "mycluster"
   ocm list machine-pools --cluster=mycluster`,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 

--- a/cmd/ocm/list/user/cmd.go
+++ b/cmd/ocm/list/user/cmd.go
@@ -34,11 +34,11 @@ var args struct {
 
 // Cmd Constant:
 var Cmd = &cobra.Command{
-	Use:     "users --cluster=mycluster [flags]",
+	Use:     "users --cluster={NAME|ID|EXTERNAL_ID}",
 	Aliases: []string{"user"},
 	Short:   "List cluster users",
 	Long:    "List administrative cluster users",
-	Args:    cobra.RangeArgs(0, 1),
+	Args:    cobra.NoArgs,
 	RunE:    run,
 }
 

--- a/cmd/ocm/list/user/cmd.go
+++ b/cmd/ocm/list/user/cmd.go
@@ -49,7 +49,7 @@ func init() {
 		"cluster",
 		"c",
 		"",
-		"Name or ID of the cluster to add the IdP to (required).",
+		"Name or ID or external_id of the cluster to add the IdP to (required).",
 	)
 	//nolint:gosec
 	Cmd.MarkFlagRequired("cluster")

--- a/cmd/ocm/list/version/cmd.go
+++ b/cmd/ocm/list/version/cmd.go
@@ -33,15 +33,11 @@ var Cmd = &cobra.Command{
 	Long:    "List the versions available for provisioning a cluster",
 	Example: `  # List all supported cluster versions
   ocm list versions`,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-
-	if len(argv) != 0 {
-		return fmt.Errorf("Expected no arguments")
-	}
-
 	// Create the client for the OCM API:
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {

--- a/cmd/ocm/login/cmd.go
+++ b/cmd/ocm/login/cmd.go
@@ -67,6 +67,7 @@ var Cmd = &cobra.Command{
 	Short: "Log in",
 	Long: "Log in, saving the credentials to the configuration file.\n" +
 		"The recommend way is using '--token', which you can obtain at: " + uiTokenPage,
+	Args: cobra.NoArgs,
 	RunE: run,
 }
 

--- a/cmd/ocm/logout/cmd.go
+++ b/cmd/ocm/logout/cmd.go
@@ -28,6 +28,7 @@ var Cmd = &cobra.Command{
 	Use:   "logout",
 	Short: "Log out",
 	Long:  "Log out, removing the configuration file.",
+	Args:  cobra.NoArgs,
 	RunE:  run,
 }
 

--- a/cmd/ocm/plugin/list/cmd.go
+++ b/cmd/ocm/plugin/list/cmd.go
@@ -34,6 +34,7 @@ var Cmd = &cobra.Command{
 	Use:   "list",
 	Short: "list ocm plugins",
 	Long:  "list all the plugins under the user executable path",
+	Args:  cobra.NoArgs,
 	RunE:  run,
 }
 

--- a/cmd/ocm/tunnel/cmd.go
+++ b/cmd/ocm/tunnel/cmd.go
@@ -30,7 +30,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "tunnel <CLUSTERID|CLUSTER_NAME|CLUSTER_NAME_SEARCH> -- [sshuttle arguments]",
+	Use:   "tunnel [flags] {CLUSTERID|CLUSTER_NAME|CLUSTER_NAME_SEARCH} -- [sshuttle arguments]",
 	Short: "tunnel to a cluster",
 	Long: "Use sshuttle to create a ssh tunnel to a cluster by ID or Name or" +
 		"cluster name search string according to the api: " +
@@ -47,7 +47,7 @@ func init() {
 func run(cmd *cobra.Command, argv []string) error {
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection:
-	if len(argv) < 1 {
+	if len(argv) != 1 {
 		fmt.Fprintf(
 			os.Stderr,
 			"Expected exactly one cluster name, identifier or external identifier "+

--- a/cmd/ocm/version/cmd.go
+++ b/cmd/ocm/version/cmd.go
@@ -29,6 +29,7 @@ var Cmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version",
 	Long:  "Prints the version number of the client.",
+	Args:  cobra.NoArgs,
 	RunE:  run,
 }
 

--- a/cmd/ocm/whoami/cmd.go
+++ b/cmd/ocm/whoami/cmd.go
@@ -32,6 +32,7 @@ var Cmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Prints user information",
 	Long:  "Prints user information.",
+	Args:  cobra.NoArgs,
 	RunE:  run,
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.2.1 // indirect
 	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect
-	github.com/spf13/cobra v0.0.6
+	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
-github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
+github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=


### PR DESCRIPTION
Most commands taking positional arguments didn't document them.  Now they do.
Also more consistently using [Cobra conventions for `Use:` line](https://github.com/spf13/cobra/blob/b97b5ead31f7d34f764ac8666e40c214bb8e06dc/command.go#L39-L48), such as "FOO_BAR" rather than "\<foo bar\>" to describe a single parameter.
Chosen approach explained in https://github.com/spf13/cobra/issues/571#issuecomment-707231598

**Behavior change:** Many commands silently ignored unexpected positional arguments (e.g. `ocm account status foo`, `ocm list clusters mycluster foo`), now they'll print an error.

- I didn't touch the generic REST commands such as `get`, `delete` etc.
  - I'm a bit confused by them (they're using `urls.Expand()` to support `get URL` & `get KIND ID` forms, but they _also_ have some Cobra sub-commands).
  - Also there is subtle terminology distinction there of "RESOURCE" (collection/single) vs "PATH" (single) that is not very clear but I wasn't sure how to improve...