### PR TITLE
ocm create cluster: Honor --parameter and --header flags

### DIFF
--- a/cmd/ocm/cluster/create/create.go
+++ b/cmd/ocm/cluster/create/create.go
@@ -226,9 +226,11 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Send a request to create the cluster:
-	response, err := cmv1Client.Clusters().Add().
-		Body(cluster).
-		Send()
+	request := cmv1Client.Clusters().Add().
+		Body(cluster)
+	arguments.ApplyParameterFlag(request, args.parameter)
+	arguments.ApplyHeaderFlag(request, args.header)
+	response, err := request.Send()
 	if err != nil {
 		return fmt.Errorf("unable to create cluster: %v", err)
 	}

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -307,7 +307,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		Private:            &args.private,
 	}
 
-	cluster, err := c.CreateCluster(cmv1Client, clusterConfig)
+	cluster, err := c.CreateCluster(cmv1Client, clusterConfig, args.parameter, args.header)
 	if err != nil {
 		return fmt.Errorf("Failed to create cluster: %v", err)
 	}

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -312,9 +312,11 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Failed to create cluster: %v", err)
 	}
 
-	err = c.PrintClusterDesctipion(connection, cluster)
-	if err != nil {
-		return err
+	if cluster != nil {
+		err = c.PrintClusterDesctipion(connection, cluster)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -104,7 +105,7 @@ func GetCluster(client *cmv1.ClustersClient, clusterKey string) (*cmv1.Cluster, 
 	}
 }
 
-func CreateCluster(cmv1Client *cmv1.Client, config Spec) (*cmv1.Cluster, error) {
+func CreateCluster(cmv1Client *cmv1.Client, config Spec, parameters []string, headers []string) (*cmv1.Cluster, error) {
 	clusterProperties := map[string]string{}
 
 	if config.CustomProperties != nil {
@@ -207,9 +208,11 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec) (*cmv1.Cluster, error) 
 	}
 
 	// Send a request to create the cluster:
-	response, err := cmv1Client.Clusters().Add().
-		Body(clusterSpec).
-		Send()
+	request := cmv1Client.Clusters().Add().
+		Body(clusterSpec)
+	arguments.ApplyParameterFlag(request, parameters)
+	arguments.ApplyHeaderFlag(request, headers)
+	response, err := request.Send()
 	if err != nil {
 		return nil, fmt.Errorf("unable to create cluster: %v", err)
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -217,6 +218,10 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec, parameters []string, he
 		return nil, fmt.Errorf("unable to create cluster: %v", err)
 	}
 
+	// Happens in dryRun mode when there were no errors.
+	if response.Status() == http.StatusNoContent {
+		return nil, nil
+	}
 	return response.Body(), nil
 }
 


### PR DESCRIPTION
In particular, `--parameter=dryRun=true` now works.

In case of no errors, results in 204 No Content, in which case I added a check to print nothing (rather than descrption full of zero values):
```
$ go run ./cmd/ocm create cluster beni-6 --parameter=dryRun=true
$ go run ./cmd/ocm create cluster beni-6 --parameter=dryRun=true --region=wrong
Error: Failed to create cluster: unable to create cluster: identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is '1gvgbb2a0ao9iuo75ps6mbq6fc961ktn': Region 'wrong' is not supported for cloud provider 'aws'
exit status 1
```

in `--debug` mode this still confuses the SDK — opened https://github.com/openshift-online/ocm-sdk-go/issues/296:
```
I1115 18:02:10.756710  792371 dump.go:143] Response status is '204 No Content'
I1115 18:02:10.756771  792371 dump.go:155] Response header 'Content-Encoding' is 'gzip'
I1115 18:02:10.756801  792371 dump.go:155] Response header 'Content-Type' is 'application/json'
I1115 18:02:10.756854  792371 dump.go:155] Response header 'Date' is 'Sun, 15 Nov 2020 16:02:10 GMT'
I1115 18:02:10.756882  792371 dump.go:155] Response header 'Vary' is 'Accept-Encoding'
I1115 18:02:10.756908  792371 dump.go:155] Response header 'X-Operation-Id' is '1gvg60n0dol7pmtv0r60hiftiqjdkt86'
I1115 18:02:10.756935  792371 dump.go:159] Response body follows
I1115 18:02:10.756974  792371 dump.go:249] 
Error: Failed to create cluster: unable to create cluster: ReadObject: expect { or , or } or n, but found , error found in #0 byte of ...||..., bigger context ...||...
exit status 1
```

But still much better than ignoring the param and creating a cluster :money_with_wings:...
