### PR TITLE
ocm create cluster --dry-run

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
     - ineffassign
     - interfacer
     - lll
-    - maligned
     - megacheck
     - misspell
     - structcheck

--- a/cmd/ocm/cluster/create/create.go
+++ b/cmd/ocm/cluster/create/create.go
@@ -24,14 +24,11 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	clusterpkg "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 )
 
 var args struct {
-	parameter         []string
-	header            []string
 	region            string
 	version           string
 	flavour           string
@@ -53,8 +50,6 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
-	arguments.AddParameterFlag(fs, &args.parameter)
-	arguments.AddHeaderFlag(fs, &args.header)
 	fs.StringVar(
 		&args.region,
 		"region",

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -26,14 +26,11 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 )
 
 var args struct {
-	parameter          []string
-	header             []string
 	region             string
 	version            string
 	flavour            string
@@ -70,8 +67,6 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
-	arguments.AddParameterFlag(fs, &args.parameter)
-	arguments.AddHeaderFlag(fs, &args.header)
 	fs.StringVar(
 		&args.region,
 		"region",

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -31,6 +31,8 @@ import (
 )
 
 var args struct {
+	dryRun bool
+
 	region             string
 	version            string
 	flavour            string
@@ -67,6 +69,13 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
+	fs.BoolVar(
+		&args.dryRun,
+		"dry-run",
+		false,
+		"Simulate creating the cluster.",
+	)
+
 	fs.StringVar(
 		&args.region,
 		"region",
@@ -302,14 +311,21 @@ func run(cmd *cobra.Command, argv []string) error {
 		Private:            &args.private,
 	}
 
-	cluster, err := c.CreateCluster(cmv1Client, clusterConfig)
+	cluster, err := c.CreateCluster(cmv1Client, clusterConfig, args.dryRun)
 	if err != nil {
 		return fmt.Errorf("Failed to create cluster: %v", err)
 	}
 
-	err = c.PrintClusterDesctipion(connection, cluster)
-	if err != nil {
-		return err
+	// Print the result:
+	if cluster == nil {
+		if args.dryRun {
+			fmt.Println("dry run: Would be successful.")
+		}
+	} else {
+		err = c.PrintClusterDesctipion(connection, cluster)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Alternative to #180.

1. Drops --parameter and --header flags from `cluster create` and `create cluster` commands.
   These never worked in these 2 commands, and it makes sense to only have them in lower-level REST commands like `ocm post`.

2. Adds `ocm create cluster --dry-run` flag.

```
$ go run ./cmd/ocm create cluster beni-7 --dry-run --region=wrong
Error: Failed to create cluster: dry run: unable to create cluster: identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is '1h007pdkir8834u880ea7bblut6nan3k': Region 'wrong' is not supported for cloud provider 'aws'
exit status 1

$ go run ./cmd/ocm create cluster beni-7 --dry-run 
dry run: Would be successful.
```

In debug mode, the successful case shows a confusing `Error: Failed to create cluster: dry run: unable to create cluster: ReadObject: expect { or , or } or n, but found , error found in #0 byte of ...||..., bigger context ...||...` error, but it's still dry, no cluster gets created, and that error will be fixed by https://github.com/openshift-online/ocm-sdk-go/pull/297