### PR TITLE
remove region display name

### DIFF
--- a/cmd/ocm/list/region/cmd.go
+++ b/cmd/ocm/list/region/cmd.go
@@ -72,16 +72,16 @@ func run(cmd *cobra.Command, argv []string) error {
 	// account-specific list on AWS CCS.
 	// Use appropriate columns to make it easier to understand, with some always true.
 	if args.provider == "aws" && args.ccs.Enabled {
-		fmt.Fprintf(writer, "ID\t\tDISPLAY NAME\tCCS (THIS AWS ACCOUNT)\tSUPPORTS MULTI-AZ\n")
+		fmt.Fprintf(writer, "ID\t\tCCS (THIS AWS ACCOUNT)\tSUPPORTS MULTI-AZ\n")
 		for _, region := range regions {
-			fmt.Fprintf(writer, "%s\t\t%s\t%v\t%v\n",
-				region.ID(), region.DisplayName(), true, region.SupportsMultiAZ())
+			fmt.Fprintf(writer, "%s\t\t%v\t%v\n",
+				region.ID(), true, region.SupportsMultiAZ())
 		}
 	} else {
-		fmt.Fprintf(writer, "ID\t\tDISPLAY NAME\tON RED HAT INFRA\tON CCS\tSUPPORTS MULTI-AZ\n")
+		fmt.Fprintf(writer, "ID\t\tON RED HAT INFRA\tON CCS\tSUPPORTS MULTI-AZ\n")
 		for _, region := range regions {
-			fmt.Fprintf(writer, "%s\t\t%s\t%v\t%v\t%v\n",
-				region.ID(), region.DisplayName(), region.Enabled(), true, region.SupportsMultiAZ())
+			fmt.Fprintf(writer, "%s\t\t%v\t%v\t%v\n",
+				region.ID(), region.Enabled(), true, region.SupportsMultiAZ())
 		}
 	}
 


### PR DESCRIPTION
We are planning to remove the display name from the UI so I'd like the CLI to match the same behavior