### PR TITLE
list versions: sort by SemVer, show default

### DIFF
--- a/cmd/ocm/list/version/cmd.go
+++ b/cmd/ocm/list/version/cmd.go
@@ -18,11 +18,9 @@ package version
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
+	"github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -44,38 +42,15 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Failed to create OCM connection: %v", err)
 	}
 	defer connection.Close()
-	// Get the client for the resource that manages the versions:
-	resource := connection.ClustersMgmt().V1().Versions()
 
-	size := 100
-	index := 1
-	for {
-		// Fetch the next page:
-		request := resource.List().Size(size).Page(index)
-		//flags.ApplyHeaderFlag(request, args.header)
-		var search strings.Builder
-		request.Search(strings.TrimSpace(search.String()))
-		response, err := request.Send()
-		if err != nil {
-			return fmt.Errorf("Can't retrieve versions: %v", err)
-		}
+	client := connection.ClustersMgmt().V1()
+	versions, _, err := cluster.GetEnabledVersions(client)
+	if err != nil {
+		return fmt.Errorf("Can't retrieve versions: %v", err)
+	}
 
-		response.Items().Each(func(version *v1.Version) bool {
-			if version.Enabled() {
-				// strip leading "openshift-v" string
-				v := strings.Replace(version.ID(), "openshift-v", "", 1)
-				fmt.Fprintf(os.Stdout, "%s\n", v)
-			}
-			return true
-		})
-
-		// If the number of fetched results is less than requested, then
-		// this was the last page, otherwise process the next one:
-		if response.Size() < size {
-			break
-		}
-
-		index++
+	for _, v := range versions {
+		fmt.Println(v)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/hashicorp/go-version v1.2.1
 	github.com/mattn/go-isatty v0.0.8
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/grokify/html-strip-tags-go v0.0.0-20200322061010-ea0c1cf2f119/go.mod 
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDGgJGQpNflI3+MJSBhsgT5PCtzBQ=

--- a/pkg/cluster/versions.go
+++ b/pkg/cluster/versions.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"sort"
+	"strings"
+
+	goVersion "github.com/hashicorp/go-version"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+const prefix = "openshift-v"
+
+func DropOpenshiftVPrefix(v string) string {
+	return strings.TrimPrefix(v, prefix)
+}
+
+func EnsureOpenshiftVPrefix(v string) string {
+	if !strings.HasPrefix(v, prefix) {
+		return prefix + v
+	}
+	return v
+}
+
+// GetEnabledVersions returns the versions with enabled=true, and the one that has default=true.
+// The returned strings are the IDs without "openshift-v" prefix (e.g. "4.6.0-rc.4-candidate")
+// sorted in approximate SemVer order (handling of text parts is somewhat arbitrary).
+func GetEnabledVersions(client *cmv1.Client) (
+	versions []string, defaultVersion string, err error) {
+	collection := client.Versions()
+	page := 1
+	size := 100
+	for {
+		response, err := collection.List().
+			Search("enabled = 'true'").
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return nil, "", err
+		}
+
+		for _, version := range response.Items().Slice() {
+			short := DropOpenshiftVPrefix(version.ID())
+			if version.Enabled() {
+				versions = append(versions, short)
+			}
+			if version.Default() {
+				defaultVersion = short
+			}
+		}
+
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+
+	sort.Slice(versions, func(i, j int) (less bool) {
+		s1, s2 := versions[i], versions[j]
+		v1, err1 := goVersion.NewVersion(s1)
+		v2, err2 := goVersion.NewVersion(s2)
+		if err1 != nil || err2 != nil {
+			// Fall back to lexicographic comparison.
+			return s1 < s2
+		}
+		return v1.LessThan(v2)
+	})
+	return versions, defaultVersion, nil
+}


### PR DESCRIPTION
# Before
`ocm list versions` dumb lexicographic order had anomalies e.g. 0 < 10 ... 19 < 2:

```
...
4.5.0-rc.6-candidate
4.5.0-rc.7-candidate
4.5.10-candidate
4.5.11
4.5.11-candidate
4.5.11-fast
4.5.12-candidate
4.5.12-fast
4.5.13-candidate
4.5.13-fast
4.5.14-candidate
4.5.14-fast
4.5.15-candidate
4.5.15-fast
4.5.16
4.5.16-candidate
4.5.16-fast
4.5.17-candidate
4.5.17-fast
4.5.18-candidate
4.5.18-fast
4.5.19-candidate
4.5.19-fast
4.5.1-candidate
4.5.1-rc.0-candidate
4.5.2-candidate
4.5.3-candidate
...
```

# After
```
$ go run ./cmd/ocm list versions
4.3.0-0.nightly-2020-11-14-031737-nightly
4.3.0-0.nightly-2020-11-16-145655-nightly
4.3.0-0.nightly-2020-11-17-155059-nightly
4.3.0-0.nightly-2020-11-17-175553-nightly
4.3.0-0.nightly-2020-11-17-213914-nightly
4.4.0-0.nightly-2020-11-13-005352-nightly
4.4.0-0.nightly-2020-11-13-030615-nightly
4.4.0-0.nightly-2020-11-13-040438-nightly
4.4.0-0.nightly-2020-11-13-173552-nightly
4.4.0-0.nightly-2020-11-13-201052-nightly
4.4.0-0.nightly-2020-11-14-032614-nightly
4.4.0-0.nightly-2020-11-15-002216-nightly
4.4.0-0.nightly-2020-11-15-015737-nightly
4.4.0-0.nightly-2020-11-15-105926-nightly
4.4.0-0.nightly-2020-11-17-174221-nightly
4.4.0-0.nightly-2020-11-17-181221-nightly
4.4.0-0.nightly-2020-11-17-204324-nightly
4.4.11-fast
4.4.11
4.4.16-fast
4.4.16
4.5.0-0.hotfix-2020-08-24-185832-candidate
4.5.0-0.nightly-2020-11-13-025510-nightly
4.5.0-0.nightly-2020-11-13-045120-nightly
4.5.0-0.nightly-2020-11-14-033431-nightly
4.5.0-0.nightly-2020-11-15-001756-nightly
4.5.0-0.nightly-2020-11-15-110315-nightly
4.5.0-0.nightly-2020-11-18-080032-nightly
4.5.0-candidate
4.5.0-rc.1-candidate
4.5.0-rc.2-candidate
4.5.0-rc.4-candidate
4.5.0-rc.5-candidate
4.5.0-rc.6-candidate
4.5.0-rc.7-candidate
4.5.1-candidate
4.5.1-rc.0-candidate
4.5.2-candidate
4.5.3-candidate
4.5.4-candidate
4.5.5-candidate
4.5.6-candidate
4.5.7-candidate
4.5.8-candidate
4.5.9-candidate
4.5.10-candidate
4.5.11-candidate
4.5.11-fast
4.5.11
4.5.12-candidate
4.5.12-fast
4.5.13-candidate
4.5.13-fast
4.5.14-candidate
4.5.14-fast
4.5.15-candidate
4.5.15-fast
4.5.16-candidate
4.5.16-fast
4.5.16
4.5.17-candidate
4.5.17-fast
4.5.18-candidate
4.5.18-fast
4.5.19-candidate
4.5.19-fast
4.5.20-candidate
4.6.0-0.nightly-2020-11-13-115928-nightly
4.6.0-0.nightly-2020-11-14-034132-nightly
4.6.0-0.nightly-2020-11-15-000915-nightly
4.6.0-0.nightly-2020-11-15-104235-nightly
4.6.0-0.nightly-2020-11-18-154058-nightly
4.6.0-candidate
4.6.0-fc.0-candidate
4.6.0-fc.1-candidate
4.6.0-fc.2-candidate
4.6.0-fc.3-candidate
4.6.0-fc.4-candidate
4.6.0-fc.5-candidate
4.6.0-fc.7-candidate
4.6.0-fc.8-candidate
4.6.0-rc.0-candidate
4.6.0-rc.1-candidate
4.6.0-rc.2-candidate
4.6.0-rc.3-candidate
4.6.0-rc.4-candidate
4.6.1-candidate
4.6.1-fast
4.6.1
4.6.2-candidate
4.6.3-candidate
4.6.3-fast
4.6.3
4.6.4-candidate
4.6.4-fast
4.6.4
4.6.5-candidate
4.7.0-0.nightly-2020-11-13-013544-nightly
4.7.0-0.nightly-2020-11-13-042205-nightly
4.7.0-0.nightly-2020-11-13-083809-nightly
4.7.0-0.nightly-2020-11-13-134746-nightly
4.7.0-0.nightly-2020-11-13-161248-nightly
4.7.0-0.nightly-2020-11-13-210751-nightly
4.7.0-0.nightly-2020-11-14-034233-nightly
4.7.0-0.nightly-2020-11-14-143620-nightly
4.7.0-0.nightly-2020-11-15-000038-nightly
4.7.0-0.nightly-2020-11-15-114305-nightly
4.7.0-0.nightly-2020-11-15-170727-nightly
4.7.0-0.nightly-2020-11-15-220851-nightly
4.7.0-0.nightly-2020-11-16-070925-nightly
4.7.0-0.nightly-2020-11-16-091948-nightly
4.7.0-0.nightly-2020-11-16-163237-nightly
4.7.0-0.nightly-2020-11-16-173710-nightly
4.7.0-0.nightly-2020-11-17-005408-nightly
4.7.0-0.nightly-2020-11-17-022018-nightly
4.7.0-0.nightly-2020-11-17-071359-nightly
4.7.0-0.nightly-2020-11-17-114024-nightly
4.7.0-0.nightly-2020-11-17-171109-nightly
4.7.0-0.nightly-2020-11-17-205931-nightly
4.7.0-0.nightly-2020-11-17-222550-nightly
4.7.0-0.nightly-2020-11-18-005758-nightly
4.7.0-0.nightly-2020-11-18-015705-nightly
4.7.0-0.nightly-2020-11-18-044518-nightly
4.7.0-0.nightly-2020-11-18-085225-nightly
4.7.0-0.nightly-2020-11-18-125028-nightly
4.7.0-0.nightly-2020-11-18-203317-nightly
```

Same order now used in `ocm create cluster` error message when given invalid version and later will be used for --interactive selection (#181).

Didn't touch `ocm cluster versions`.

@igoihman @nimrodshn 