### PR TITLE
Use Must() wrapper to panic in case of wrong flag names in code

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -111,16 +111,14 @@ func init() {
 		args.expirationTime,
 		"Specified time when cluster should expire (RFC3339). Only one of expiration-time / expiration may be used.",
 	)
-	//nolint:gosec
-	fs.MarkHidden("expiration-time")
+	arguments.Must(Cmd.Flags().MarkHidden("expiration-time"))
 	fs.DurationVar(
 		&args.expirationSeconds,
 		"expiration",
 		args.expirationSeconds,
 		"Expire cluster after a relative duration like 2h, 8h, 72h. Only one of expiration-time / expiration may be used.",
 	)
-	//nolint:gosec
-	fs.MarkHidden("expiration")
+	arguments.Must(Cmd.Flags().MarkHidden("expiration"))
 	fs.BoolVar(
 		&args.private,
 		"private",

--- a/cmd/ocm/create/idp/cmd.go
+++ b/cmd/ocm/create/idp/cmd.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -84,8 +85,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to add the IdP to (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 
 	flags.StringVarP(
 		&args.idpType,

--- a/cmd/ocm/create/ingress/cmd.go
+++ b/cmd/ocm/create/ingress/cmd.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -54,8 +55,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to add the ingress to (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 
 	flags.BoolVar(
 		&args.private,

--- a/cmd/ocm/create/machinepool/cmd.go
+++ b/cmd/ocm/create/machinepool/cmd.go
@@ -57,8 +57,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to add the machine pool to (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 
 	flags.StringVar(
 		&args.instanceType,
@@ -66,9 +65,7 @@ func init() {
 		"",
 		"Instance type that should be used.",
 	)
-
-	//nolint:gosec
-	Cmd.MarkFlagRequired("instance-type")
+	arguments.Must(Cmd.MarkFlagRequired("instance-type"))
 
 	flags.IntVar(
 		&args.replicas,
@@ -76,9 +73,7 @@ func init() {
 		0,
 		"Count of machines for this machine pool.",
 	)
-
-	//nolint:gosec
-	Cmd.MarkFlagRequired("replicas")
+	arguments.Must(Cmd.MarkFlagRequired("replicas"))
 
 	flags.StringVar(
 		&args.labels,

--- a/cmd/ocm/create/upgradepolicy/cmd.go
+++ b/cmd/ocm/create/upgradepolicy/cmd.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -53,8 +54,7 @@ func init() {
 		"",
 		"Name or ID of the cluster to add the machine pool to (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/create/user/cmd.go
+++ b/cmd/ocm/create/user/cmd.go
@@ -20,6 +20,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 )
@@ -49,8 +50,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to add the user to (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 
 	flags.StringVar(
 		&args.group,
@@ -58,8 +58,7 @@ func init() {
 		"",
 		"Group name to add the users to (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("group")
+	arguments.Must(Cmd.MarkFlagRequired("group"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/delete/idp/cmd.go
+++ b/cmd/ocm/delete/idp/cmd.go
@@ -19,6 +19,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 )
@@ -47,8 +48,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to delete the IdP from (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/delete/ingress/cmd.go
+++ b/cmd/ocm/delete/ingress/cmd.go
@@ -20,6 +20,7 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 )
@@ -51,8 +52,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to delete the ingress from (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/delete/machinepool/cmd.go
+++ b/cmd/ocm/delete/machinepool/cmd.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 )
@@ -46,8 +47,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to delete the machine pool from (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/delete/upgradepolicy/cmd.go
+++ b/cmd/ocm/delete/upgradepolicy/cmd.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 )
@@ -46,8 +47,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to delete the upgrade policy from (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/delete/user/cmd.go
+++ b/cmd/ocm/delete/user/cmd.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 )
@@ -47,8 +48,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to delete the user from (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 
 	flags.StringVar(
 		&args.group,
@@ -56,8 +56,7 @@ func init() {
 		"",
 		"Group name to delete the user from.",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("group")
+	arguments.Must(Cmd.MarkFlagRequired("group"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/edit/cluster/cmd.go
+++ b/cmd/ocm/edit/cluster/cmd.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 )
@@ -57,8 +58,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster.",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 
 	// Basic options
 	flags.StringVar(
@@ -74,10 +74,8 @@ func init() {
 		"Expire cluster after a relative duration like 2h, 8h, 72h. Only one of expiration-time / expiration may be used.",
 	)
 	// Cluster expiration is not supported in production
-	//nolint:gosec
-	flags.MarkHidden("expiration-time")
-	//nolint:gosec
-	flags.MarkHidden("expiration")
+	arguments.Must(flags.MarkHidden("expiration-time"))
+	arguments.Must(flags.MarkHidden("expiration"))
 
 	// Scaling options
 	flags.IntVar(

--- a/cmd/ocm/edit/ingress/cmd.go
+++ b/cmd/ocm/edit/ingress/cmd.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -54,8 +55,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to add the ingress to (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 
 	flags.BoolVar(
 		&args.private,

--- a/cmd/ocm/edit/machinepool/cmd.go
+++ b/cmd/ocm/edit/machinepool/cmd.go
@@ -16,6 +16,7 @@ package machinepool
 import (
 	"fmt"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -47,8 +48,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to edit the machine pool (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 
 	flags.IntVar(
 		&args.replicas,

--- a/cmd/ocm/list/addon/cmd.go
+++ b/cmd/ocm/list/addon/cmd.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -50,8 +51,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to list the add-ons of (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/list/idp/cmd.go
+++ b/cmd/ocm/list/idp/cmd.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -50,8 +51,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to list the IdP of (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/list/ingress/cmd.go
+++ b/cmd/ocm/list/ingress/cmd.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -54,8 +55,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to list the routes of (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/list/machinepool/cmd.go
+++ b/cmd/ocm/list/machinepool/cmd.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -54,8 +55,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to list the machine pools of (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/list/region/cmd.go
+++ b/cmd/ocm/list/region/cmd.go
@@ -42,9 +42,10 @@ var Cmd = &cobra.Command{
 
 func init() {
 	fs := Cmd.Flags()
+
 	arguments.AddProviderFlag(fs, &args.provider)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("provider")
+	arguments.Must(Cmd.MarkFlagRequired("provider"))
+
 	arguments.AddCCSFlagsWithoutAccountID(fs, &args.ccs)
 }
 

--- a/cmd/ocm/list/upgradepolicy/cmd.go
+++ b/cmd/ocm/list/upgradepolicy/cmd.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -53,8 +54,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to list the upgrade policies of (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/list/user/cmd.go
+++ b/cmd/ocm/list/user/cmd.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -51,8 +52,7 @@ func init() {
 		"",
 		"Name or ID or external_id of the cluster to add the IdP to (required).",
 	)
-	//nolint:gosec
-	Cmd.MarkFlagRequired("cluster")
+	arguments.Must(Cmd.MarkFlagRequired("cluster"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -57,11 +57,7 @@ var root = &cobra.Command{
 
 func init() {
 	// Send logs to the standard error stream by default:
-	err := flag.Set("logtostderr", "true")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't set default error stream: %v\n", err)
-		os.Exit(1)
-	}
+	arguments.Must(flag.Set("logtostderr", "true"))
 
 	// Register the options that are managed by the 'flag' package, so that they will also be parsed
 	// by the 'pflag' package:

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -35,6 +35,13 @@ import (
 	"github.com/openshift-online/ocm-cli/pkg/debug"
 )
 
+// Must panics if err != nil. Useful for lookups of flags by name, e.g. MarkHidden()...
+func Must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
 type FilePath string
 
 func (f *FilePath) String() string {


### PR DESCRIPTION
@igoihman @vkareh please review.

gosec has a point, this is better than just discarding the error.  Now in case of a typo in flag name in code, we'll get something like:
```
$ go run ./cmd/ocm whatever
panic: flag "xpiration-time" does not exist

goroutine 1 [running]:
github.com/openshift-online/ocm-cli/pkg/arguments.Must(...)
	/home/cben/openshift/ocm-cli/pkg/arguments/arguments.go:40
github.com/openshift-online/ocm-cli/cmd/ocm/edit/cluster.init.0()
	/home/cben/openshift/ocm-cli/cmd/ocm/edit/cluster/cmd.go:77 +0x2b4
exit status 2
```

Future TODO: This is not yet caught by `make test` and would not fail CI, but it wouldn't before this PR either.
It'll become covered if we add docs or completions generation like in moactl.