### PR TITLE
refactor machine types helpers

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -529,67 +529,6 @@ func cidrIsEmpty(cidr net.IPNet) bool {
 	return cidr.String() == "<nil>"
 }
 
-func getMachineTypes(client *cmv1.Client, provider string) (machineTypes []*cmv1.MachineType, err error) {
-	collection := client.MachineTypes()
-	page := 1
-	size := 100
-	for {
-		var response *cmv1.MachineTypesListResponse
-		response, err = collection.List().
-			Search(fmt.Sprintf("cloud_provider.id = '%s'", provider)).
-			Order("size desc").
-			Page(page).
-			Size(size).
-			Send()
-		if err != nil {
-			return
-		}
-		machineTypes = append(machineTypes, response.Items().Slice()...)
-		if response.Size() < size {
-			break
-		}
-		page++
-	}
-	return
-}
-
-func ValidateMachineType(client *cmv1.Client, provider string, machineType string) (string, error) {
-	machineTypeList, err := getMachineTypeList(client, provider)
-	if err != nil {
-		return "", err
-	}
-	if machineType != "" {
-		// Check and set the cluster machineType
-		hasMachineType := false
-		for _, v := range machineTypeList {
-			if v == machineType {
-				hasMachineType = true
-			}
-		}
-		if !hasMachineType {
-			allMachineTypes := strings.Join(machineTypeList, " ")
-			err := fmt.Errorf("A valid machine type number must be specified\nValid machine types: %s", allMachineTypes)
-			return machineType, err
-		}
-	}
-
-	return machineType, nil
-}
-
-func getMachineTypeList(client *cmv1.Client, provider string) (machineTypeList []string, err error) {
-	machineTypes, err := getMachineTypes(client, provider)
-	if err != nil {
-		err = fmt.Errorf("Failed to retrieve machine types: %s", err)
-		return
-	}
-
-	for _, v := range machineTypes {
-		machineTypeList = append(machineTypeList, v.ID())
-	}
-
-	return
-}
-
 func ValidateClusterExpiration(
 	expirationTime string,
 	expirationDuration time.Duration,

--- a/pkg/provider/machine_types.go
+++ b/pkg/provider/machine_types.go
@@ -1,0 +1,64 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"fmt"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+func getMachineTypes(client *cmv1.Client, provider string) (machineTypes []*cmv1.MachineType, err error) {
+	collection := client.MachineTypes()
+	page := 1
+	size := 100
+	for {
+		var response *cmv1.MachineTypesListResponse
+		response, err = collection.List().
+			Search(fmt.Sprintf("cloud_provider.id = '%s'", provider)).
+			Order("size desc").
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return
+		}
+		machineTypes = append(machineTypes, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+
+	if len(machineTypes) == 0 {
+		return nil, fmt.Errorf("No machine types for provider %v", err)
+	}
+	return
+}
+
+func GetMachineTypeIDs(client *cmv1.Client, provider string) (machineTypeList []string, err error) {
+	machineTypes, err := getMachineTypes(client, provider)
+	if err != nil {
+		err = fmt.Errorf("Failed to retrieve machine types: %s", err)
+		return
+	}
+
+	for _, v := range machineTypes {
+		machineTypeList = append(machineTypeList, v.ID())
+	}
+	return
+}


### PR DESCRIPTION
Extracted from WIP #181.
The new argument helper will make more sense after I add the other interactive ones; I included it here only to support the removal of a separate `ValidateMachineType` function.
@igoihman @vkareh please review.

- [x] `ocm create cluster` still allows omitting --compute-machine-type.
- [x] --compute-machine-type=wrong still shows an error, slightly changed:
  ```diff
  -Error: Expected a valid machine type: A valid machine type number must be specified
  -Valid machine types: m5.xlarge r5.xlarge m5.2xlarge c5.2xlarge r5.2xlarge m5.4xlarge c5.4xlarge r5.4xlarge
  +Error: A valid --compute-machine-type must be specified.
  +Valid options: [m5.xlarge r5.xlarge m5.2xlarge c5.2xlarge r5.2xlarge m5.4xlarge c5.4xlarge r5.4xlarge]
  ```
- [x] `ocm create machinepool` still errors if --instance-type not provided:
  ```
  Error: required flag(s) "instance-type" not set
  ```
- [x] --instance-type=wrong still shows an error, slightly changed:
  ```diff
  -Error: Expected a valid machine type: A valid machine type number must be specified
  -Valid machine types: m5.xlarge r5.xlarge m5.2xlarge c5.2xlarge r5.2xlarge m5.4xlarge c5.4xlarge r5.4xlarge
  +Error: A valid --instance-type must be specified.
  +Valid options: [m5.xlarge r5.xlarge m5.2xlarge c5.2xlarge r5.2xlarge m5.4xlarge c5.4xlarge r5.4xlarge]
  ```

The offered options depend on cloud provider, for GCP it says instead:
```
Valid options: [custom-4-16384 custom-4-32768-ext custom-8-32768 custom-8-16384 custom-8-65536-ext custom-16-65536 custom-16-32768 custom-16-131072-ext]
```