### PR TITLE
Correct upstream import of go-isatty

### DIFF
--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -26,7 +26,7 @@ import (
 	"reflect"
 	"strings"
 
-	isatty "github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty"
+	isatty "github.com/mattn/go-isatty"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"


### PR DESCRIPTION
Revert import that I guess was changed accidentally in #192?
https://github.com/onsi/ginkgo/tree/master/reporters/stenographer/support/go-isatty/ is an older, unmaintained, copy of upstream https://github.com/mattn/go-isatty/
@igoihman please confirm.