### PR TITLE
Fix `ocm create cluster --ccs --provider=aws`

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -177,7 +177,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) error {
 	var err error
-	if args.region == "us-east-1" && args.provider != "aws" {
+	if args.region == "us-east-1" && args.provider != c.ProviderAWS {
 		return fmt.Errorf("if specifying a non-aws cloud provider, region must be set to a valid region")
 	}
 
@@ -244,7 +244,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		clusterFlavour = args.flavour
 	}
 
-	if args.private && args.provider != "aws" {
+	if args.private && args.provider != c.ProviderAWS {
 		return fmt.Errorf("Setting cluster as private is not supported for cloud provider '%s'", args.provider)
 	}
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -30,6 +30,11 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
+const (
+	ProviderAWS = "aws"
+	ProviderGCP = "gcp"
+)
+
 // Spec is the configuration for a cluster spec.
 type Spec struct {
 	// Basic configs
@@ -209,7 +214,7 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec, dryRun bool) (*cmv1.Clu
 
 	if config.CCS.Enabled {
 		clusterBuilder = clusterBuilder.CCS(cmv1.NewCCS().Enabled(true))
-		if config.Provider == "AWS" {
+		if config.Provider == ProviderAWS {
 			clusterBuilder = clusterBuilder.AWS(
 				cmv1.NewAWS().
 					AccountID(config.CCS.AWS.AccountID).

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -214,14 +214,15 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec, dryRun bool) (*cmv1.Clu
 
 	if config.CCS.Enabled {
 		clusterBuilder = clusterBuilder.CCS(cmv1.NewCCS().Enabled(true))
-		if config.Provider == ProviderAWS {
+		switch config.Provider {
+		case ProviderAWS:
 			clusterBuilder = clusterBuilder.AWS(
 				cmv1.NewAWS().
 					AccountID(config.CCS.AWS.AccountID).
 					AccessKeyID(config.CCS.AWS.AccessKeyID).
 					SecretAccessKey(config.CCS.AWS.SecretAccessKey),
 			)
-		} else {
+		case ProviderGCP:
 			clusterBuilder =
 				clusterBuilder.GCP(
 					cmv1.NewGCP().
@@ -236,7 +237,8 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec, dryRun bool) (*cmv1.Clu
 						AuthProviderX509CertURL(config.CCS.GCP.AuthProviderX509CertURL).
 						ClientX509CertURL(config.CCS.GCP.ClientX509CertURL),
 				)
-
+		default:
+			return nil, fmt.Errorf("Unexpected CCS provider %q", config.Provider)
 		}
 	}
 


### PR DESCRIPTION
Provider id can be "aws", never "AWS".  The wrong comparison caused the CCS code to always send GCP fields, and never send AWS fields, resulting in error :boom::
```
$ go run ./cmd/ocm create cluster cben-5 --dry-run --ccs --aws-access-key-id=AKIA3EM67QKY33CSWLMK --aws-secret-access-key=(cat ~/.aws/credentials | grep aws_secret_access_key | cut --delimiter=' ' --fields=3 | tr -d \n) --debuggo run ./cmd/ocm create cluster cben-5 --dry-run --ccs --aws-account-id=765374464689 --aws-access-key-id=AKIA3EM67QKY33CSWLMK --aws-secret-access-key=(cat ~/.aws/credentials | grep aws_secret_access_key | cut --delimiter=' ' --fields=3 | tr -d \n) --debug
...
I1221 20:00:21.217566  369671 dump.go:136] Request body follows
I1221 20:00:21.218108  369671 dump.go:258] {
  "kind": "Cluster",
  "api": {
    "listening": "external"
  },
  "ccs": {
    "kind": "CCS",
    "enabled": true
  },
  "gcp": {
    "auth_uri": "",
    "auth_provider_x509_cert_url": "",
    "client_id": "",
    "client_x509_cert_url": "",
    "client_email": "",
    "private_key": "",
    "private_key_id": "",
    "project_id": "",
    "token_uri": "",
    "type": ""
  },
  "cloud_provider": {
    "kind": "CloudProvider",
    "id": "aws"
  },
  "display_name": "cben-5",
  "flavour": {
    "kind": "Flavour",
    "id": "osd-4"
  },
  "multi_az": false,
  "name": "cben-5",
  "nodes": {
    "compute": 4
  },
  "properties": {},
  "region": {
    "kind": "CloudRegion",
    "id": "us-east-1"
  }
}
...
I1221 20:00:21.494533  369671 dump.go:258] {
  "kind": "Error",
  "id": "400",
  "href": "/api/clusters_mgmt/v1/errors/400",
  "code": "CLUSTERS-MGMT-400",
  "reason": "Client email '' received in the service account credentials, has a wrong format of email address.",
  "operation_id": "1hn99dbuqnb5i651bjm52l0nlc0t85u6"
}
Error: Failed to create cluster: dry run: unable to create cluster: identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is '1hn99dbuqnb5i651bjm52l0nlc0t85u6': Client email '' received in the service account credentials, has a wrong format of email address.
exit status 1
```
Now sends correct request:
```
I1221 20:11:51.880928  378395 dump.go:258] {
  "kind": "Cluster",
  "api": {
    "listening": "external"
  },
  "aws": {
    "access_key_id": "AKIA3EM67QKY33CSWLMK",
    "account_id": "765374464689",
    "secret_access_key": "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"
  },
  "ccs": {
    "kind": "CCS",
    "enabled": true
  },
  "cloud_provider": {
    "kind": "CloudProvider",
    "id": "aws"
  },
  "display_name": "cben-5",
  "flavour": {
    "kind": "Flavour",
    "id": "osd-4"
  },
  "multi_az": false,
  "name": "cben-5",
  "nodes": {
    "compute": 4
  },
  "properties": {},
  "region": {
    "kind": "CloudRegion",
    "id": "us-east-1"
  }
}
```