### PR TITLE
ocm completion: support other shells

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,7 +46,7 @@ brews:
       bin.install "ocm"
 
       # Install bash completion
-      output = Utils.popen_read("#{bin}/ocm completion")
+      output = Utils.popen_read("#{bin}/ocm completion bash")
       (bash_completion/"ocm").write output
     test: |
       assert_match /^#{version}/, shell_output("#{bin}/ocm version")

--- a/README.adoc
+++ b/README.adoc
@@ -53,6 +53,14 @@ used doesn't support modules, because the dependencies used may not be the ones
 tested by the developers. In general installations done with `go get` aren't
 supported or recommended.
 
+== Activating shell completions
+
+Run the following to see instructions for various shells:
+
+....
+$ ocm completion --help
+....
+
 == Log In
 
 The first step to use the tool is to log-in with your OpenShift Cluster Manager


### PR DESCRIPTION
Already had bash, now also supports zsh, fish, powershell.
Tested on fish, bash, zsh:
[![asciicast](https://asciinema.org/a/381735.svg)](https://asciinema.org/a/381735)