### PR TITLE
Dynamic completion of flag values --region= etc.

### DIFF
--- a/cmd/ocm/create/machinepool/cmd.go
+++ b/cmd/ocm/create/machinepool/cmd.go
@@ -157,7 +157,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
 	}
 
-	machineTypeList, err := provider.GetMachineTypeIDs(connection.ClustersMgmt().V1(),
+	machineTypeList, err := provider.GetMachineTypeOptions(connection.ClustersMgmt().V1(),
 		cluster.CloudProvider().ID())
 	if err != nil {
 		return err

--- a/pkg/provider/machine_types.go
+++ b/pkg/provider/machine_types.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"fmt"
 
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
@@ -50,7 +51,7 @@ func getMachineTypes(client *cmv1.Client, provider string) (machineTypes []*cmv1
 	return
 }
 
-func GetMachineTypeIDs(client *cmv1.Client, provider string) (machineTypeList []string, err error) {
+func GetMachineTypeOptions(client *cmv1.Client, provider string) (options []arguments.Option, err error) {
 	machineTypes, err := getMachineTypes(client, provider)
 	if err != nil {
 		err = fmt.Errorf("Failed to retrieve machine types: %s", err)
@@ -58,7 +59,10 @@ func GetMachineTypeIDs(client *cmv1.Client, provider string) (machineTypeList []
 	}
 
 	for _, v := range machineTypes {
-		machineTypeList = append(machineTypeList, v.ID())
+		options = append(options, arguments.Option{
+			Value:       v.ID(),
+			Description: v.Name(),
+		})
 	}
 	return
 }


### PR DESCRIPTION
Improved shell completion — can now complete some flag values based on results from server --provider, --region, --version, --flavour, --compute-machine-type.
In some shells (fish, zsh) can show extra info for the completions :sparkles:.  In --interactive mode the descriptions are not used (not currently supported by `survey` library).
[![asciicast](https://asciinema.org/a/r6ZSapnhpBP0k8CGR2alDwwso.svg)](https://asciinema.org/a/r6ZSapnhpBP0k8CGR2alDwwso)