### PR TITLE
Fix CheckOneOf() error message

### DIFF
--- a/pkg/arguments/interactive.go
+++ b/pkg/arguments/interactive.go
@@ -340,7 +340,7 @@ func doPromptOneOf(fs *pflag.FlagSet, flagName string, options []Option) error {
 			optionValues[i] = option.Value
 		}
 
-		// If the `Default` is one of the allowed `Options`,
+		// If the `Default` is not one of the allowed `Options`,
 		// survey.Select may keep it if the user immediately presses Enter
 		// without moving the cursor.
 		// https://github.com/AlecAivazis/survey/pull/284


### PR DESCRIPTION
In #205, I broke the error message when passing e.g. `--region=foo` to look silly:

    Error: A valid --region must be specified.
    Valid options: [{Value:ap-northeast-1 Description:Asia Pacific, Tokyo} {Value:ap-northeast-2 Description:Asia Pacific, Seoul} {Value:ap-south-1 Description:Asia Pacific, Mumbai} {Value:ap-southeast-1 Description:Asia Pacific, Singapore} {Value:ap-southeast-2 Description:Asia Pacific, Sydney} {Value:ca-central-1 Description:Canada, Central} {Value:eu-central-1 Description:EU, Frankfurt} {Value:eu-north-1 Description:EU, Stockholm} {Value:eu-west-1 Description:EU, Ireland} {Value:eu-west-2 Description:EU, London} {Value:eu-west-3 Description:EU, Paris} {Value:me-south-1 Description:Middle East, Bahrain} {Value:sa-east-1 Description:South America, São Paulo} {Value:us-east-1 Description:US East, N. Virginia} {Value:us-east-2 Description:US East, Ohio} {Value:us-west-1 Description:US West, N. California} {Value:us-west-2 Description:US West, Oregon}]

Now restored to show:

    Error: A valid --region must be specified.
    Valid options: [ap-northeast-1 ap-northeast-2 ap-south-1 ap-southeast-1 ap-southeast-2 ca-central-1 eu-central-1 eu-north-1 eu-west-1 eu-west-2 eu-west-3 me-south-1 sa-east-1 us-east-1 us-east-2 us-west-1 us-west-2]

@igoihman @nimrodshn @vkareh please review.
Is the concise output good, or should I take advantage of the Description field and print a pretty table?  IMHO concise errors are fine since we have commands like `ocm list regions` to get a full picture.