### PR TITLE
Fix create cluster command with autoscaling

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -385,7 +385,7 @@ func preRun(cmd *cobra.Command, argv []string) error {
 		return err
 	}
 
-	err = arguments.CheckIgnoredAutoscalingFlags(args.autoscaling, args.computeNodes)
+	err = arguments.CheckAutoscalingFlags(args.autoscaling, args.computeNodes)
 	if err != nil {
 		return err
 	}
@@ -622,15 +622,19 @@ func promptAutoscaling(fs *pflag.FlagSet) error {
 		return err
 	}
 	if args.autoscaling.Enabled {
-		// set default
-		args.autoscaling.MinReplicas = minComputeNodes(args.ccs.Enabled, args.multiAZ)
+		// set default for interactive mode
+		if args.interactive && args.autoscaling.MinReplicas == 0 {
+			args.autoscaling.MinReplicas = minComputeNodes(args.ccs.Enabled, args.multiAZ)
+		}
 		err = arguments.PromptInt(fs, "min-replicas", validateAutoscalingMin)
 		if err != nil {
 			return err
 		}
 
-		// set default
-		args.autoscaling.MaxReplicas = args.autoscaling.MinReplicas
+		// set default for interactive mode
+		if args.interactive && args.autoscaling.MaxReplicas == 0 {
+			args.autoscaling.MaxReplicas = args.autoscaling.MinReplicas
+		}
 		err = arguments.PromptInt(fs, "max-replicas", validateAutoscalingMax)
 		if err != nil {
 			return err

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -183,9 +183,11 @@ func AddAutoscalingFlags(fs *pflag.FlagSet, value *cluster.Autoscaling) {
 	SetQuestion(fs, "max-replicas", "Max replicas:")
 }
 
-// CheckIgnoredAutoscalingFlags errors if --min-replicas or --max-replicas
+// CheckAutoscalingFlags errors if --min-replicas or --max-replicas
 // were used without --enable-autoscaling (and vice-versa with --compute-nodes)
-func CheckIgnoredAutoscalingFlags(autoscaling cluster.Autoscaling, computeNodes int) error {
+// It also errors if --min-replicas or --max-replicas were not supplied
+// when --enable-autoscaling is used
+func CheckAutoscalingFlags(autoscaling cluster.Autoscaling, computeNodes int) error {
 	if !autoscaling.Enabled {
 		bad := []string{}
 		if autoscaling.MinReplicas != 0 {
@@ -203,6 +205,14 @@ func CheckIgnoredAutoscalingFlags(autoscaling cluster.Autoscaling, computeNodes 
 	} else {
 		if computeNodes != 0 {
 			return fmt.Errorf("--compute-nodes is meaningless with --enable-autoscaling")
+		}
+
+		if autoscaling.MinReplicas == 0 {
+			return fmt.Errorf("--min-replicas flag is required with --enable-autoscaling")
+		}
+
+		if autoscaling.MaxReplicas == 0 {
+			return fmt.Errorf("--max-replicas flag is required with --enable-autoscaling")
 		}
 	}
 


### PR DESCRIPTION
There should be defaults for min/max replicas only for interactive mode.
Otherwise, they are required when --enable-autoscaling is set.

Related: https://issues.redhat.com/browse/SDA-3702