### PR TITLE
Fix empty edit default machine pool

### DIFF
--- a/cmd/ocm/edit/machinepool/cmd.go
+++ b/cmd/ocm/edit/machinepool/cmd.go
@@ -61,7 +61,7 @@ func init() {
 		&args.replicas,
 		"replicas",
 		-1,
-		"Restrict application route to direct, private connectivity.",
+		"Count of machines for this machine pool.",
 	)
 
 	arguments.AddAutoscalingFlags(flags, &args.autoscaling)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -168,7 +168,7 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec, dryRun bool) (*cmv1.Clu
 
 	}
 
-	if config.ComputeMachineType != "" || config.ComputeNodes != 0 ||
+	if config.ComputeMachineType != "" || config.ComputeNodes > 0 ||
 		config.Autoscaling.Enabled {
 		clusterNodesBuilder := cmv1.NewClusterNodes()
 		if config.ComputeMachineType != "" {
@@ -283,7 +283,7 @@ func UpdateCluster(client *cmv1.ClustersClient, clusterID string, config Spec) e
 	}
 
 	// Scale cluster
-	if config.ComputeNodes != 0 || config.Autoscaling.Enabled {
+	if config.ComputeNodes > 0 || config.Autoscaling.Enabled {
 		clusterBuilder = clusterBuilder.Nodes(buildCompute(config, cmv1.NewClusterNodes()))
 	}
 
@@ -325,7 +325,7 @@ func buildCompute(config Spec, clusterNodesBuilder *cmv1.ClusterNodesBuilder) *c
 			autoscalingBuilder = autoscalingBuilder.MaxReplicas(config.Autoscaling.MaxReplicas)
 		}
 		clusterNodesBuilder = clusterNodesBuilder.AutoscaleCompute(autoscalingBuilder)
-	} else if config.ComputeNodes != 0 {
+	} else if config.ComputeNodes > 0 {
 		clusterNodesBuilder = clusterNodesBuilder.Compute(config.ComputeNodes)
 	}
 	return clusterNodesBuilder


### PR DESCRIPTION
This bug was caused because we use the same func to create and update the nodes builder for a cluster.
It would only update if computes nodes != 0 (which means it was set by the user).
However, the default for edit additional machine pool is -1, because 0 is a valid value.
Since we now use the same `edit machinepool` command for default and additional,
I changed the check to `if computeNodes > 0` which captures both cases.
Related: https://issues.redhat.com/browse/SDA-3709

This also includes a documentation fix for --replicas flag.
Related: https://issues.redhat.com/browse/SDA-3710