### PR TITLE
add --dns flag to sshuttle

### DIFF
--- a/cmd/ocm/tunnel/cmd.go
+++ b/cmd/ocm/tunnel/cmd.go
@@ -93,7 +93,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	sshuttleArgs := []string{
-		"--remote", sshURL,
+		"--dns", "--remote", sshURL,
 		cluster.Network().MachineCIDR(),
 		cluster.Network().ServiceCIDR(),
 		cluster.Network().PodCIDR(),


### PR DESCRIPTION
This is to resolve private cluster urls that stopped being resolved after a `dnf upgrade` for fedora33 users.