### PR TITLE
Add support for hibernate/resume cluster

### DIFF
--- a/cmd/ocm/hibernate/cluster/cmd.go
+++ b/cmd/ocm/hibernate/cluster/cmd.go
@@ -1,0 +1,65 @@
+package cluster
+
+import (
+	"fmt"
+	"os"
+
+	c "github.com/openshift-online/ocm-cli/pkg/cluster"
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "cluster {NAME|ID|EXTERNAL_ID}",
+	Short: "Initiate cluster hibernation",
+	Long: "Initiates cluster hibernation. While hibernating a cluster will not consume any cloud provider infrastructure" +
+		"but will be counted for quota.",
+	RunE: run,
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	// Check that there is exactly one cluster name, identifir or external identifier in the
+	// command line arguments:
+	if len(argv) != 1 {
+		fmt.Fprintf(
+			os.Stderr,
+			"Expected exactly one cluster name, identifier or external identifier "+
+				"is required\n",
+		)
+		os.Exit(1)
+	}
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := argv[0]
+	if !c.IsValidClusterKey(clusterKey) {
+		return fmt.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+	}
+
+	// Create the client for the OCM API:
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("Failed to create OCM connection: %v", err)
+	}
+	defer connection.Close()
+
+	// Get the client for the cluster management api
+	clusterCollection := connection.ClustersMgmt().V1().Clusters()
+
+	// Verify the cluster exists in OCM.
+	cluster, err := c.GetCluster(clusterCollection, clusterKey)
+	if err != nil {
+		return fmt.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+	}
+
+	_, err = clusterCollection.Cluster(cluster.ID()).Hibernate().Send()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/ocm/hibernate/cmd.go
+++ b/cmd/ocm/hibernate/cmd.go
@@ -1,0 +1,16 @@
+package hibernate
+
+import (
+	"github.com/openshift-online/ocm-cli/cmd/ocm/hibernate/cluster"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "hibernate [flags] RESOURCE",
+	Short: "Hibernate a specific resource (currently only supported for clusters)",
+	Long:  "Hibernate a specific resource (currently only supported for clusters)",
+}
+
+func init() {
+	Cmd.AddCommand(cluster.Cmd)
+}

--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -35,12 +35,14 @@ import (
 	"github.com/openshift-online/ocm-cli/cmd/ocm/describe"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/edit"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/get"
+	"github.com/openshift-online/ocm-cli/cmd/ocm/hibernate"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/list"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/login"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/logout"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/patch"
 	plugincmd "github.com/openshift-online/ocm-cli/cmd/ocm/plugin"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/post"
+	"github.com/openshift-online/ocm-cli/cmd/ocm/resume"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/token"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/tunnel"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/version"
@@ -91,6 +93,8 @@ func init() {
 	root.AddCommand(whoami.Cmd)
 	root.AddCommand(config.Cmd)
 	root.AddCommand(plugincmd.Cmd)
+	root.AddCommand(hibernate.Cmd)
+	root.AddCommand(resume.Cmd)
 }
 
 func main() {

--- a/cmd/ocm/resume/cluster/cmd.go
+++ b/cmd/ocm/resume/cluster/cmd.go
@@ -1,0 +1,63 @@
+package cluster
+
+import (
+	"fmt"
+	"os"
+
+	c "github.com/openshift-online/ocm-cli/pkg/cluster"
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "cluster {NAME|ID|EXTERNAL_ID}",
+	Short: "Resume a cluster from hibernation",
+	Long:  "Resumes cluster hibernation. The cluster will return to a `Ready` state, and all actions will be enabled.",
+	RunE:  run,
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	// Check that there is exactly one cluster name, identifir or external identifier in the
+	// command line arguments:
+	if len(argv) != 1 {
+		fmt.Fprintf(
+			os.Stderr,
+			"Expected exactly one cluster name, identifier or external identifier "+
+				"is required\n",
+		)
+		os.Exit(1)
+	}
+
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection:
+	clusterKey := argv[0]
+	if !c.IsValidClusterKey(clusterKey) {
+		return fmt.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+	}
+
+	// Create the client for the OCM API:
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("Failed to create OCM connection: %v", err)
+	}
+	defer connection.Close()
+
+	// Get the client for the cluster management api
+	clusterCollection := connection.ClustersMgmt().V1().Clusters()
+
+	// Verify the cluster exists in OCM.
+	cluster, err := c.GetCluster(clusterCollection, clusterKey)
+	if err != nil {
+		return fmt.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
+	}
+	_, err = clusterCollection.Cluster(cluster.ID()).Resume().Send()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/ocm/resume/cmd.go
+++ b/cmd/ocm/resume/cmd.go
@@ -1,0 +1,16 @@
+package resume
+
+import (
+	"github.com/openshift-online/ocm-cli/cmd/ocm/resume/cluster"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "resume [flags] RESOURCE",
+	Short: "Resumes a hibernating resource (currently only supported for clusters)",
+	Long:  "Resumes a hibernating resource (currently only supported for clusters)",
+}
+
+func init() {
+	Cmd.AddCommand(cluster.Cmd)
+}


### PR DESCRIPTION
cc: @igoihman  @jhernand @cben 

Example usage: 
```
// Hibernate a cluster
ocm hibernate cluster <cluster-id>

// Resume a cluster
ocm resume cluster <cluster-id>
```