### PR TITLE
Add switch for tunnel to use in-continuous IPs

### DIFF
--- a/cmd/ocm/tunnel/cmd.go
+++ b/cmd/ocm/tunnel/cmd.go
@@ -18,6 +18,8 @@ package tunnel
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"regexp"
@@ -28,6 +30,10 @@ import (
 	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/spf13/cobra"
 )
+
+var args struct {
+	hostOnly bool
+}
 
 var Cmd = &cobra.Command{
 	Use:   "tunnel [flags] {CLUSTERID|CLUSTER_NAME|CLUSTER_NAME_SEARCH} -- [sshuttle arguments]",
@@ -42,6 +48,14 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
+	flags := Cmd.Flags()
+	flags.BoolVarP(
+		&args.hostOnly,
+		"host-only",
+		"",
+		false,
+		"Only tunnel to the IPs of console and api server, instead of the whole subnet.",
+	)
 }
 
 func run(cmd *cobra.Command, argv []string) error {
@@ -94,9 +108,25 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	sshuttleArgs := []string{
 		"--dns", "--remote", sshURL,
-		cluster.Network().MachineCIDR(),
-		cluster.Network().ServiceCIDR(),
-		cluster.Network().PodCIDR(),
+	}
+
+	if args.hostOnly {
+		consoleIPs, err := resolveURL(cluster.Console().URL())
+		if err != nil {
+			return fmt.Errorf("can't get console IPs: %s", err)
+		}
+		apiIPs, err := resolveURL(cluster.API().URL())
+		if err != nil {
+			return fmt.Errorf("can't get api server IPs: %s", err)
+		}
+
+		sshuttleArgs = append(sshuttleArgs, consoleIPs...)
+		sshuttleArgs = append(sshuttleArgs, apiIPs...)
+	} else {
+		sshuttleArgs = append(sshuttleArgs,
+			cluster.Network().MachineCIDR(),
+			cluster.Network().ServiceCIDR(),
+			cluster.Network().PodCIDR())
 	}
 	sshuttleArgs = append(sshuttleArgs, argv[1:]...)
 
@@ -128,4 +158,21 @@ func generateSSHURI(cluster *clustersmgmtv1.Cluster) (string, error) {
 	}
 
 	return "sre-user@rh-ssh." + base, nil
+}
+
+func resolveURL(rawurl string) ([]string, error) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, fmt.Errorf("can't parse url: %s", err)
+	}
+	hostname := u.Hostname()
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		return nil, fmt.Errorf("failed looking up %s: %s", hostname, err)
+	}
+	result := []string{}
+	for _, ip := range ips {
+		result = append(result, ip.String())
+	}
+	return result, nil
 }


### PR DESCRIPTION
In the current tunnel implementation, tunnel will redirect traffic for the whole subnet of MachineCIDR, ServiceCIDR and PodCIDR. The subnet range is too large, and if the user want to tunnel to multiple clusters, the CIDR has a large chance to conflict.

For SRE, usually we need to tunnel to a target cluster for simple troubleshoot, and having tunnel to API server & console should be enough. Hence, adding a flag --host-only to only tunnel to apiserver & console IPs. 

```
$ ocm tunnel <cluster-name> 
   # /usr/bin/sshuttle --dns --remote sre-user@rh-ssh.xxxx.xxxx.xx.openshiftapps.com 10.aaa.0.0/16 bbb.ccc.0.0/16 ddd.eee.0.0/14

$ ocm tunnel --host-only <cluster-name>
   # /usr/bin/sshuttle --dns --remote sre-user@rh-ssh.xxxx.xxxx.xx.openshiftapps.com 10.aaa.bbb.ccc 10.aaa.ddd.eee 10.aaa.fff.ggg
```
PS. I know `host-only` is a bad name. Let me know if you got a better name.