### PR TITLE
remove: revert #244 as we have ocm tunnel -- --dns

### DIFF
--- a/cmd/ocm/tunnel/cmd.go
+++ b/cmd/ocm/tunnel/cmd.go
@@ -108,7 +108,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	sshuttleArgs := []string{
-		"--dns", "--remote", sshURL,
+		"--remote", sshURL,
 	}
 
 	if args.useSubnets {


### PR DESCRIPTION
The flag also can be used as "ocm tunnel ID -- --dns" if needed, so no need to re-define it.
Also, no need to use the cluster-side resolution as the addresses are public.