### PR TITLE
Merge search parameter into search query for `list clusters`

### DIFF
--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -252,14 +252,7 @@ func applyNVFlag(request interface{}, method string, values []string) {
 	// Split the values into name value pairs and call the method for each one:
 	for _, value := range values {
 		var name string
-		position := strings.Index(value, "=")
-		if position != -1 {
-			name = value[:position]
-			value = value[position+1:]
-		} else {
-			name = value
-			value = ""
-		}
+		name, value = ParseNameValuePair(value)
 		args := []reflect.Value{
 			reflect.ValueOf(name),
 			reflect.ValueOf(value),
@@ -306,4 +299,17 @@ func ApplyPathArg(request *sdk.Request, value string) error {
 
 func Split(r rune) bool {
 	return r == '=' || r == ':'
+}
+
+// ParseNameValuePair parses a name value pair.
+func ParseNameValuePair(text string) (name, value string) {
+	position := strings.Index(text, "=")
+	if position != -1 {
+		name = strings.TrimSpace(text[:position])
+		value = text[position+1:]
+	} else {
+		name = strings.TrimSpace(text)
+		value = ""
+	}
+	return
 }


### PR DESCRIPTION
Currently when the `--parameter search="..."` flag is used in the `list clusters` command the result is that two `search` query parameters are sent to the server, one containing the value given by the `--parameter` flag and another containing the search query calculated from the rest of the flags. For example, the following command:

```
$ ocm list clusters --managed --parameter search="state is 'ready'"
```

Results in a URL like this:

```
https://api.openshift.com/foo/bar?search=managed+%27t%27&search=state+is+%27ready%27
```

When the server receive that it will just ignore one of the values, so the result will not the expected combination of both search criteria.

To address that this patch changes the `list clusters` command so that it will explicitly combine the search query calculated from other parameters with the values given with the `--parameter` flag. In the above example the result will be a URL like this:

```
https://api.openshift.com/api/clusters_mgmt/v1/clusters?search=%28managed+%3D+%27t%27%29+and+%28state+is+%27ready%27%29
```

Note that this only applies to the `list clusters` command. The `--parameter search="..."` flag will still have the previous meaning in other places.

Related: https://issues.redhat.com/browse/SDA-4201