### PR TITLE
Add PrivateLink To Describe Cluster

### DIFF
--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -125,6 +125,11 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 		}
 	}
 
+	privateLinkEnabled := false
+	if cluster.CloudProvider().ID() == ProviderAWS && cluster.AWS() != nil {
+		privateLinkEnabled = cluster.AWS().PrivateLink()
+	}
+
 	// Print short cluster description:
 	fmt.Printf("\n"+
 		"ID:            %s\n"+
@@ -143,6 +148,7 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 		"Region:        %s\n"+
 		"Multi-az:      %t\n"+
 		"CCS:           %t\n"+
+		"PrivateLink:   %t\n"+
 		"Channel Group: %v\n"+
 		"Cluster Admin: %t\n"+
 		"Organization:  %s\n"+
@@ -166,6 +172,7 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 		cluster.Region().ID(),
 		cluster.MultiAZ(),
 		cluster.CCS().Enabled(),
+		privateLinkEnabled,
 		cluster.Version().ChannelGroup(),
 		clusterAdminEnabled,
 		organization,


### PR DESCRIPTION
This adds the PrivateLink descriptor to the `describe cluster` command.

Card: OSD-7343

Example:
```
$ ./ocm describe cluster 1kqafv545aqi0ig05qefh6t334dgbuee

ID:            1kqafv545aqi0ig05qefh6t334dgbuee
External ID:   cb49454b-0f95-49fb-85a2-327899d5e7aa
Name:          drow-pl-01
State:         ready
API URL:       https://api.drow-pl-01.htno.p1.openshiftapps.com:6443
API Listening: internal
Console URL:   https://console-openshift-console.apps.drow-pl-01.htno.p1.openshiftapps.com
Masters:       3
Infra:         2
Computes:      2
Product:       rosa
Provider:      aws
Version:       4.7.9
Region:        us-east-1
Multi-az:      false
CCS:           true
PrivateLink:   true
Channel Group: stable
Cluster Admin: true
Organization:  Red Hat OpenShift Online
Creator:       drow.openshift.srep
Email:         drow@redhat.com
Created:       2021-05-20T23:51:28Z
Expiration:    0001-01-01T00:00:00Z
Shard:         https://api.hivep01ue1.b6s7.p1.openshiftapps.com:6443
```