### PR TITLE
ocm post: pass correct info to ApplyHeaderFlag()

### DIFF
--- a/cmd/ocm/post/cmd.go
+++ b/cmd/ocm/post/cmd.go
@@ -71,7 +71,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		os.Exit(1)
 	}
 	arguments.ApplyParameterFlag(request, args.parameter)
-	arguments.ApplyHeaderFlag(request, args.parameter)
+	arguments.ApplyHeaderFlag(request, args.header)
 	err = arguments.ApplyBodyFlag(request, args.body)
 	if err != nil {
 		return fmt.Errorf("Can't read body: %v", err)


### PR DESCRIPTION
The header flags are stored in args.header, not in args.parameter