### PR TITLE
Add table printer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+*.orig
+*.patch
+*.rej
 /ocm
 /ocm-darwin-amd64
 /ocm-darwin-amd64.sha256sum
 /ocm-linux-amd64
 /ocm-linux-amd64.sha256sum
+bindata.go

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,19 @@ export CGO_ENABLED=0
 # Allow overriding: `make lint container_runner=docker`.
 container_runner:=podman
 
+.PHONY: all
+all: cmds
+
+.PHONY: tools
+tools:
+	which go-bindata || go get github.com/go-bindata/go-bindata/go-bindata
+
+.PHONY: generate
+generate: tools
+	go generate -x ./cmd/... ./pkg/...
+
 .PHONY: cmds
-cmds:
+cmds: generate
 	for cmd in $$(ls cmd); do \
 		go build -o "$${cmd}" "./cmd/$${cmd}" || exit 1; \
 	done

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,6 @@ require (
 	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 // indirect
 	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/apimachinery v0.18.5
 )

--- a/pkg/data/digger.go
+++ b/pkg/data/digger.go
@@ -1,0 +1,325 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the implementation of an object that knows how to extract data from objects
+// using paths.
+
+package data
+
+import (
+	"context"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+// DiggerBuilder contains the information and logic needed to build a digger.
+type DiggerBuilder struct {
+}
+
+// Digger is an object that knows how to extract information from objects using paths.
+type Digger struct {
+	methodCache     map[cacheKey]reflect.Method
+	methodCacheLock *sync.Mutex
+	fieldCache      map[cacheKey]int
+	fieldCacheLock  *sync.Mutex
+}
+
+// cacheKey is used as the key for the methods and fields caches.
+type cacheKey struct {
+	class reflect.Type
+	field string
+}
+
+// NewDigger creates a builder that can then be used to configure and create diggers.
+func NewDigger() *DiggerBuilder {
+	return &DiggerBuilder{}
+}
+
+// Build uses the configuration stored in the builder to create a new digger.
+func (b *DiggerBuilder) Build(ctx context.Context) (result *Digger, err error) {
+	// Create and populate the object:
+	result = &Digger{
+		methodCache:     map[cacheKey]reflect.Method{},
+		methodCacheLock: &sync.Mutex{},
+		fieldCache:      map[cacheKey]int{},
+		fieldCacheLock:  &sync.Mutex{},
+	}
+
+	return
+}
+
+// Dig extracts from the given object the field that corresponds to the given path. The path should
+// be a sequence of field names separated by dots.
+func (d *Digger) Dig(object interface{}, path string) interface{} {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return object
+	}
+	segments := strings.Split(path, ".")
+	if len(segments) == 0 {
+		return object
+	}
+	for i, field := range segments {
+		segments[i] = strings.TrimSpace(field)
+	}
+	return d.digPath(object, segments)
+}
+
+func (d *Digger) digPath(object interface{}, path []string) interface{} {
+	if len(path) == 0 {
+		return object
+	}
+	head := path[0]
+	next := d.digField(object, head)
+	if next == nil {
+		return nil
+	}
+	tail := path[1:]
+	return d.digPath(next, tail)
+}
+
+func (d *Digger) digField(object interface{}, field string) interface{} {
+	value := reflect.ValueOf(object)
+	return d.digFieldFromValue(value, field)
+}
+
+func (d *Digger) digFieldFromValue(value reflect.Value, field string) interface{} {
+	switch value.Kind() {
+	case reflect.Ptr:
+		return d.digFieldFromPtr(value, field)
+	case reflect.Struct:
+		return d.digFieldFromStruct(value, field)
+	default:
+		return nil
+	}
+}
+
+func (d *Digger) digFieldFromPtr(value reflect.Value, name string) interface{} {
+	// Try to find a matching method:
+	method, ok := d.lookupMethod(value.Type(), name)
+	if ok {
+		return d.digFieldFromMethod(value, method)
+	}
+
+	// If no matching method was found, but the target of the pointer is a struct then we should
+	// try to extract the field from the public methods of the struct.
+	if value.Type().Elem().Kind() == reflect.Struct {
+		return d.digFieldFromStruct(value.Elem(), name)
+	}
+
+	// If we are here we didn't find any match:
+	return nil
+}
+
+func (d *Digger) digFieldFromStruct(value reflect.Value, name string) interface{} {
+	// First try to find a matching method:
+	method, ok := d.lookupMethod(value.Type(), name)
+	if ok {
+		return d.digFieldFromMethod(value, method)
+	}
+
+	// If no matching method was found, try to find a matching public field:
+	index, ok := d.lookupField(value.Type(), name)
+	if ok {
+		return value.Field(index).Interface()
+	}
+
+	// If we are here we didn't find any match:
+	return nil
+}
+
+func (d *Digger) digFieldFromMethod(value reflect.Value, method reflect.Method) interface{} {
+	var result reflect.Value
+
+	// Call the method:
+	inArgs := []reflect.Value{
+		value,
+	}
+	outArgs := method.Func.Call(inArgs)
+
+	// If the method has one output parameter then we assume it is the value. If it has two
+	// output parameters then we assume that the first is the value and the second is a boolean
+	// flag indicating if there is actually a value.
+	switch len(outArgs) {
+	case 1:
+		result = outArgs[0]
+	case 2:
+		if outArgs[1].Bool() {
+			result = outArgs[0]
+		}
+	}
+
+	// Return the result:
+	if !result.IsValid() {
+		return nil
+	}
+	return result.Interface()
+}
+
+// lookupMethod tries to find a method of the given value that matches the given path segment. For
+// example, if the path segment is `my_field` it will look for a method named `GetMyField` or
+// `MyField`. Only methods that don't have input parameters will be considered.
+func (d *Digger) lookupMethod(class reflect.Type, field string) (result reflect.Method, ok bool) {
+	// Acquire the method cache lock:
+	d.methodCacheLock.Lock()
+	defer d.methodCacheLock.Unlock()
+
+	// Try to find the method in the cache:
+	key := cacheKey{
+		class: class,
+		field: field,
+	}
+	result, ok = d.methodCache[key]
+	if ok {
+		return
+	}
+
+	// Get the number of methods:
+	count := class.NumMethod()
+
+	// Try to find a method that returns a value and a boolean flag indicating if there is
+	// actually a value. We try this first because this gives more information and allows us to
+	// return nil when the field isn't present, instead of returning the zero value of the type.
+	for i := 0; i < count; i++ {
+		method := class.Method(i)
+		if method.Type.NumIn() != 1 || method.Type.NumOut() != 2 {
+			continue
+		}
+		if method.Type.Out(1).Kind() != reflect.Bool {
+			continue
+		}
+		if !d.methodNameMatches(method.Name, field) {
+			continue
+		}
+		d.methodCache[key] = method
+		result = method
+		ok = true
+		return
+	}
+
+	// Try now to find a method that returns only the value.
+	for i := 0; i < count; i++ {
+		method := class.Method(i)
+		if method.Type.NumIn() != 1 || method.Type.NumOut() != 1 {
+			continue
+		}
+		if !d.methodNameMatches(method.Name, field) {
+			continue
+		}
+		d.methodCache[key] = method
+		result = method
+		ok = true
+		return
+	}
+
+	// If we are here then we didn't find any matching method.
+	ok = false
+	return
+}
+
+// methodNameMatches checks if the name of a Go method matches a path segment.
+func (d *Digger) methodNameMatches(method, segment string) bool {
+	// If there is a `Get` prefix remove it:
+	name := method
+	if getMethodRE.MatchString(method) {
+		name = name[3:]
+	}
+
+	// Check if the method name matches the segment:
+	return d.nameMatches(name, segment)
+}
+
+// lookupField tries to find a field of the given value that matches the given path segment. For
+// example, if the path segment is `my_field` it will look for a field named `MyField`.
+func (d *Digger) lookupField(class reflect.Type, name string) (result int, ok bool) {
+	// Acquire the field cache lock:
+	d.fieldCacheLock.Lock()
+	defer d.fieldCacheLock.Unlock()
+
+	// Try to find the field in the cache:
+	key := cacheKey{
+		class: class,
+		field: name,
+	}
+	result, ok = d.fieldCache[key]
+	if ok {
+		return
+	}
+
+	// Try now to find a field that matches the name:
+	count := class.NumField()
+	for i := 0; i < count; i++ {
+		field := class.Field(i)
+		if !d.fieldNameMatches(field.Name, name) {
+			continue
+		}
+		d.fieldCache[key] = i
+		result = i
+		ok = true
+		return
+	}
+
+	// If we are here then we didn't find any matching method.
+	ok = false
+	return
+}
+
+// fieldNameMatches checks if the name of a Go fields matches a path segment.
+func (d *Digger) fieldNameMatches(field, segment string) bool {
+	return d.nameMatches(field, segment)
+}
+
+// nameMatches checks if a Go name matches with a path segment.
+func (d *Digger) nameMatches(name, segment string) bool {
+	// Conver the strings to arrays of runes so that we can compare runes one by one easily:
+	nameRunes := []rune(name)
+	nameLen := len(nameRunes)
+	segmentRunes := []rune(segment)
+	segmentLen := len(segmentRunes)
+
+	// Start at the beginning of both arrays of runes, and advance while the runes in both the
+	// name and the path segment are compatible. Two runes are compatible if they are equal
+	// ignoring case. An underscore in the path segment is compatible if there is a transition
+	// from lower case to upper case in the name at that point.
+	nameI, segmentI := 0, 0
+	for nameI < nameLen && segmentI < segmentLen {
+		if unicode.ToLower(nameRunes[nameI]) == unicode.ToLower(segmentRunes[segmentI]) {
+			nameI++
+			segmentI++
+			continue
+		}
+		if nameI > 0 && segmentRunes[segmentI] == '_' {
+			previousLower := unicode.IsLower(nameRunes[nameI-1])
+			currentUpper := unicode.IsUpper(nameRunes[nameI])
+			if previousLower && currentUpper {
+				segmentI++
+				continue
+			}
+		}
+		return false
+	}
+
+	// If we have consumed all the runes of both names then there is a match:
+	return nameI == nameLen && segmentI == segmentLen
+}
+
+// getMethodRE is a regular expression used to check if a method name starts with `Get`. Note that
+// checking if the string starts with `Get` is not enough as it would fails for methods with names
+// like `Getaway`.
+var getMethodRE = regexp.MustCompile(`^Get\p{Lu}`)

--- a/pkg/data/digger_test.go
+++ b/pkg/data/digger_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package data
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Digger", func() {
+	var digger *Digger
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx := context.Background()
+
+		// Create the digger:
+		digger, err = NewDigger().
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	DescribeTable(
+		"Dig",
+		func(object interface{}, path string, expected interface{}) {
+			actual := digger.Dig(object, path)
+			if expected == nil {
+				Expect(actual).To(BeNil())
+			} else {
+				Expect(actual).To(Equal(expected))
+			}
+		},
+		Entry(
+			"Empty path on nil",
+			nil,
+			"",
+			nil,
+		),
+		Entry(
+			"Path with one segment on nil",
+			nil,
+			"a",
+			nil,
+		),
+		Entry(
+			"Path with two segments on nil",
+			nil,
+			"a.b",
+			nil,
+		),
+		Entry(
+			"Empty path on pointer",
+			&subject{},
+			"",
+			&subject{},
+		),
+		Entry(
+			"Path to method returning value",
+			&subject{},
+			"a",
+			"a_value",
+		),
+		Entry(
+			"Path to method returning value and true",
+			&subject{},
+			"b",
+			"b_value",
+		),
+		Entry(
+			"Path to method returning value and false",
+			&subject{},
+			"c",
+			nil,
+		),
+		Entry(
+			"Path with one underscore",
+			&subject{},
+			"my_d",
+			"my_d_value",
+		),
+		Entry(
+			"Path with two segments",
+			&subject{},
+			"s.a",
+			"s/a_value",
+		),
+		Entry(
+			"Path with three segments",
+			&subject{},
+			"s.s.a",
+			"s/s/a_value",
+		),
+		Entry(
+			"Integer method",
+			&subject{},
+			"e",
+			123,
+		),
+		Entry(
+			"Float method",
+			&subject{},
+			"f",
+			1.23,
+		),
+		Entry(
+			"Time method",
+			&subject{},
+			"g",
+			time.Unix(1, 23),
+		),
+		Entry(
+			"Duration method",
+			&subject{},
+			"h",
+			time.Duration(123),
+		),
+		Entry(
+			"Prefers `Get...` and returns nil for false",
+			&subject{},
+			"i",
+			nil,
+		),
+		Entry(
+			"Doesn't remove `Get...` prefix if not followed by word",
+			&subject{},
+			"getaway",
+			"getaway_value",
+		),
+		Entry(
+			"Value receiver",
+			subject{},
+			"j",
+			"j_value",
+		),
+		Entry(
+			"String field",
+			subject{
+				K: "k_value",
+			},
+			"k",
+			"k_value",
+		),
+		Entry(
+			"Integer field",
+			subject{
+				L: 123,
+			},
+			"l",
+			123,
+		),
+		Entry(
+			"Float field",
+			subject{
+				M: 1.23,
+			},
+			"m",
+			1.23,
+		),
+		Entry(
+			"Time field",
+			subject{
+				O: time.Unix(1, 23),
+			},
+			"o",
+			time.Unix(1, 23),
+		),
+		Entry(
+			"Duration field",
+			subject{
+				P: time.Duration(123),
+			},
+			"p",
+			time.Duration(123),
+		),
+		Entry(
+			"Nil field",
+			subject{
+				Q: nil,
+			},
+			"q",
+			nil,
+		),
+		Entry(
+			"Field that doesn't exist",
+			subject{},
+			"does_not_exist",
+			nil,
+		),
+	)
+})
+
+// subject is used as a subject of the digger tests.
+type subject struct {
+	prefix string
+	K      string
+	L      int
+	M      float64
+	O      time.Time
+	P      time.Duration
+	Q      *int
+}
+
+func (s *subject) S() *subject {
+	return &subject{
+		prefix: s.prefix + "s/",
+	}
+}
+
+func (s *subject) A() string {
+	return s.prefix + "a_value"
+}
+
+func (s *subject) GetB() (value string, ok bool) {
+	value = s.prefix + "b_value"
+	ok = true
+	return
+}
+
+func (s *subject) GetC() (value string, ok bool) {
+	value = s.prefix + "c_value"
+	ok = false
+	return
+}
+
+func (s *subject) MyD() string {
+	return s.prefix + "my_d_value"
+}
+
+func (s *subject) E() int {
+	return 123
+}
+
+func (s *subject) F() float64 {
+	return 1.23
+}
+
+func (s *subject) G() time.Time {
+	return time.Unix(1, 23)
+}
+
+func (s *subject) H() time.Duration {
+	return time.Duration(123)
+}
+
+func (s *subject) I() string {
+	return ""
+}
+
+func (s *subject) GetI() (value string, ok bool) {
+	value = ""
+	ok = false
+	return
+}
+
+func (s *subject) Getaway() string {
+	return "getaway_value"
+}
+
+func (s subject) J() string {
+	return "j_value"
+}

--- a/pkg/data/main_test.go
+++ b/pkg/data/main_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package data
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+func TestData(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Data")
+}

--- a/pkg/output/main_test.go
+++ b/pkg/output/main_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+func TestOutput(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Output")
+}

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -1,0 +1,327 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the code that writes generates tabular output.
+
+//go:generate go-bindata -pkg output tables
+
+package output
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openshift-online/ocm-cli/pkg/data"
+	"gopkg.in/yaml.v3"
+)
+
+// TableBuilder contains the data and logic needed to create a new output table.
+type TableBuilder struct {
+	printer *Printer
+	name    string
+	specs   []string
+	digger  *data.Digger
+}
+
+// Table contains the data and logic needed to write tabular output.
+type Table struct {
+	printer *Printer
+	name    string
+	columns []*Column
+	digger  *data.Digger
+}
+
+// tableYAML is used to load a table description from a YAML document.
+type tableYAML struct {
+	Columns []*columnYAML `yaml:"columns"`
+}
+
+// Column contains the data and logic needed to write columns.
+type Column struct {
+	name   string
+	header string
+	width  int
+}
+
+// columnYAML is used to load a column description from a YAML document.
+type columnYAML struct {
+	Name   *string `yaml:"name"`
+	Header *string `yaml:"header"`
+	Width  *int    `yaml:"width"`
+}
+
+// NewTable creates a new builder that can then be used to configure and create a table.
+func (p *Printer) NewTable() *TableBuilder {
+	return &TableBuilder{
+		printer: p,
+	}
+}
+
+// Name sets the name of the table. This is mandatory.
+func (b *TableBuilder) Name(value string) *TableBuilder {
+	b.name = value
+	return b
+}
+
+// Column adds a column to the table. The spec can be a single column identifier or a set of comma
+// separated column identifiers.
+func (b *TableBuilder) Column(spec string) *TableBuilder {
+	b.specs = append(b.specs, spec)
+	return b
+}
+
+// Columns adds a collection of columns to the table. Each spec can be a single column identifier or
+// a set of comman separated column identifiers.
+func (b *TableBuilder) Columns(specs ...string) *TableBuilder {
+	b.specs = append(b.specs, specs...)
+	return b
+}
+
+// Digger sets the digger that will be used to extract fields from row objects. If not specified the
+// digger of the printer will be used.
+func (b *TableBuilder) Digger(value *data.Digger) *TableBuilder {
+	b.digger = value
+	return b
+}
+
+// Build uses the configuration stored in the builder to create a table.
+func (b *TableBuilder) Build(ctx context.Context) (result *Table, err error) {
+	// Check parameters:
+	if b.printer == nil {
+		err = fmt.Errorf("printer is mandatory")
+		return
+	}
+	if b.name == "" {
+		err = fmt.Errorf("name is mandatory")
+		return
+	}
+	if len(b.specs) == 0 {
+		err = fmt.Errorf("at least one column is required")
+		return
+	}
+
+	// Split the column specifications into individual column names:
+	columnNames := make([]string, 0, len(b.specs))
+	for _, specs := range b.specs {
+		specChunks := strings.Split(specs, ",")
+		for _, specChunk := range specChunks {
+			columnName := strings.TrimSpace(specChunk)
+			if columnName != "" {
+				columnNames = append(columnNames, columnName)
+			}
+		}
+	}
+
+	// Load the table description:
+	table, err := b.loadTable(columnNames)
+	if err != nil {
+		return
+	}
+
+	// Create the digger if needed:
+	table.digger = b.digger
+	if b.digger == nil {
+		table.digger = b.printer.digger
+	}
+
+	// Return the result:
+	result = table
+	return
+}
+
+func (b *TableBuilder) loadTable(columnNames []string) (result *Table, err error) {
+	// Create an initially empty table:
+	table := &Table{
+		printer: b.printer,
+		name:    b.name,
+		columns: []*Column{},
+	}
+
+	// Check if there is an asset corresponding to the table. If there is no asset then return
+	// the empty table description:
+	assetFile := fmt.Sprintf("tables/%s.yaml", b.name)
+	assetData, err := Asset(assetFile)
+	if err != nil {
+		result = table
+		return
+	}
+
+	// Parse the YAML document from the asset:
+	var tableData tableYAML
+	err = yaml.Unmarshal(assetData, &tableData)
+	if err != nil {
+		return
+	}
+
+	// Load the descriptions of the columns from the asset:
+	columnsFromAsset := make([]*Column, len(tableData.Columns))
+	for i, columnData := range tableData.Columns {
+		columnsFromAsset[i], err = b.loadColumn(i, columnData)
+		if err != nil {
+			return
+		}
+	}
+
+	// Create the list of columns using the descriptions loaded from the asset, or else default
+	// descriptions for the columns that aren't described in the asset:
+	table.columns = make([]*Column, len(columnNames))
+	for i, columnName := range columnNames {
+		var column *Column
+		for _, columnFromAsset := range columnsFromAsset {
+			if columnFromAsset.name == columnName {
+				column = columnFromAsset
+				break
+			}
+		}
+		if column == nil {
+			column = b.defaultColumn(columnName)
+		}
+		table.columns[i] = column
+	}
+
+	// Return the table:
+	result = table
+	return
+}
+
+// loadColumnYAML copies the column data from the YAML document to the object.
+func (b *TableBuilder) loadColumn(i int, columnData *columnYAML) (result *Column, err error) {
+	// Check that the name of the column has been specified:
+	if columnData.Name == nil || *columnData.Name == "" {
+		err = fmt.Errorf(
+			"column %d of table '%s' doesn't have a name",
+			i, b.name,
+		)
+		return
+	}
+	columnName := *columnData.Name
+
+	// Create an initially empty column:
+	column := b.defaultColumn(columnName)
+
+	// Copy the data from the YAML document:
+	if columnData.Header != nil {
+		column.header = *columnData.Header
+	}
+	if columnData.Width != nil {
+		column.width = *columnData.Width
+	}
+
+	// Return the column:
+	result = column
+	return
+}
+
+// defaultColumn creates a default column description for the given column name.
+func (b *TableBuilder) defaultColumn(columnName string) *Column {
+	return &Column{
+		name:   columnName,
+		header: b.defaultColumnHeader(columnName),
+		width:  b.defaultColumnWidth(columnName),
+	}
+}
+
+// defaultColumnHeader returns the default value for the header of the given column name.
+func (b *TableBuilder) defaultColumnHeader(columnName string) string {
+	columnHeader := columnName
+	columnHeader = strings.ReplaceAll(columnHeader, ".", " ")
+	columnHeader = strings.ReplaceAll(columnHeader, "_", " ")
+	columnHeader = strings.ToUpper(columnHeader)
+	return columnHeader
+}
+
+// defaultColumnWidth returns the default width for the given column name.
+func (b *TableBuilder) defaultColumnWidth(columnName string) int {
+	return len(columnName)
+}
+
+// WriteColumns writes a row of a table using the given values.
+func (t *Table) WriteColumns(columnValues []interface{}) error {
+	// Check that the number of values matches the number of columns:
+	valueCount := len(columnValues)
+	columnCount := len(t.columns)
+	if valueCount != columnCount {
+		return fmt.Errorf(
+			"table '%s' has %d columns, but %d values have been given",
+			t.name, columnCount, valueCount,
+		)
+	}
+
+	// Prepare a buffer to write the columns (sum of the widths of the columns plus two
+	// characters to separate columns, and the new line):
+	tableWidth := 2 * columnCount
+	for _, column := range t.columns {
+		tableWidth += column.width
+	}
+	var rowBuffer bytes.Buffer
+	rowBuffer.Grow(tableWidth)
+
+	// Write the values while trimming or padding to adjust to the desired sizes:
+	for i, columnValue := range columnValues {
+		if i > 0 {
+			rowBuffer.WriteString("  ")
+		}
+		var columnText string
+		if columnValue != nil {
+			columnText = fmt.Sprintf("%v", columnValue)
+		} else {
+			columnText = "NONE"
+		}
+		actualWidth := len(columnText)
+		desiredWidth := t.columns[i].width
+		switch {
+		case actualWidth > desiredWidth:
+			rowBuffer.WriteString(columnText[0:desiredWidth])
+		case actualWidth < desiredWidth:
+			rowBuffer.WriteString(columnText)
+			for j := 0; j < desiredWidth-actualWidth; j++ {
+				rowBuffer.WriteString(" ")
+			}
+		default:
+			rowBuffer.WriteString(columnText)
+		}
+	}
+	rowBuffer.WriteString("\n")
+
+	// Write the content of the buffer:
+	_, err := rowBuffer.WriteTo(t.printer)
+	return err
+}
+
+// WriteHeaders writes the headers of the columns of the table.
+func (t *Table) WriteHeaders() error {
+	headers := make([]interface{}, len(t.columns))
+	for i, column := range t.columns {
+		headers[i] = column.header
+	}
+	return t.WriteColumns(headers)
+}
+
+// WriteRow writes a row of a table extracting the values of the columns from the given object.
+func (t *Table) WriteRow(row interface{}) error {
+	fields := make([]interface{}, len(t.columns))
+	for i, column := range t.columns {
+		fields[i] = t.digger.Dig(row, column.name)
+	}
+	return t.WriteColumns(fields)
+}
+
+// Close releases all the resources used by the table.
+func (t *Table) Close() error {
+	return nil
+}

--- a/pkg/output/table_test.go
+++ b/pkg/output/table_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"bytes"
+	"context"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+var _ = Describe("Table", func() {
+	var ctx context.Context
+	var buffer *bytes.Buffer
+	var printer *Printer
+
+	BeforeEach(func() {
+		var err error
+
+		// Create a context:
+		ctx = context.Background()
+
+		// Create the buffer:
+		buffer = &bytes.Buffer{}
+
+		// Create a printer that writes to a memory buffer so that we can check the results:
+		printer, err = NewPrinter().
+			Writer(buffer).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		var err error
+
+		// Close the printer:
+		if printer != nil {
+			err = printer.Close()
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	It("Writes headers", func() {
+		// Create the table:
+		table, err := printer.NewTable().
+			Name("clusters").
+			Columns(
+				"id",
+				"external_id",
+				"name",
+			).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Write the headers:
+		err = table.WriteHeaders()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check the generated text:
+		Expect(buffer.String()).To(MatchRegexp(
+			`^ID\s+EXTERNAL ID\s+NAME\s+$`,
+		))
+	})
+
+	It("Doesn't trim `external_id` column", func() {
+		// Create the table:
+		table, err := printer.NewTable().
+			Name("clusters").
+			Columns(
+				"id",
+				"external_id",
+				"name",
+			).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the object that will be written to the table:
+		object, err := cmv1.NewCluster().
+			ID("123").
+			ExternalID("e30bac0b-b337-47d7-a378-2c302b4c868a").
+			Name("mycluster").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Write the object to the table:
+		err = table.WriteRow(object)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check the generated text:
+		Expect(buffer.String()).To(MatchRegexp(
+			`^123\s+e30bac0b-b337-47d7-a378-2c302b4c868a\s+mycluster\s+$`,
+		))
+	})
+
+	It("Writes `NONE` for columns without value", func() {
+		// Create the table:
+		table, err := printer.NewTable().
+			Name("clusters").
+			Columns(
+				"id",
+				"external_id",
+				"name",
+			).
+			Build(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create the object that will be written to the table:
+		object, err := cmv1.NewCluster().
+			ID("123").
+			Name("mycluster").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Write the object to the table:
+		err = table.WriteRow(object)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Check the generated text:
+		Expect(buffer.String()).To(MatchRegexp(
+			`^123\s+NONE\s+mycluster\s+$`,
+		))
+	})
+})

--- a/pkg/output/tables/clusters.yaml
+++ b/pkg/output/tables/clusters.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+columns:
+- name: id
+  header: ID
+  width: 32
+- name: name
+  header: NAME
+  width: 28
+- name: api.url
+  header: API URL
+  width: 58
+- name: openshift_version
+  header: OPENSHIFT_VERSION
+  width: 18
+- name: product.id
+  header: PRODUCT ID
+  width: 14
+- name: cloud_provider.id
+  header: CLOUD_PROVIDER
+  width: 14
+- name: region.id
+  header: REGION ID
+  width: 14
+- name: state
+  header: STATE
+  width: 13
+- name: external_id
+  header: EXTERNAL ID
+  width: 36


### PR DESCRIPTION
Add table printer

This patch adds a new `output.Table` type that simplifies writing
tabular ouptut. It is created from the `output.Printer` type introduced
in a previous patch:

```go
// Create the output table:
table, err := printer.NewTable().
        Name("clusters").
        Columns(args.columns).
        Build(ctx)
if err != nil {
        return err
}
```

When a table like this is created it reads the descriptions of the
columns from the corresponding file in the `pkg/output/tables`
directory. In this case it will read the `clusters.yaml` file. That file
should contain the descriptions of the columns of that table, in
particular it should contain the preferred width of the columns. For
example:

```yaml
columns:
- name: id
  header: ID
  width: 32
- name: name
  header: NAME
  width: 28
  ...
- name: external_id
  header: EXTERNAL ID
  width: 36
```

In this example the `external_id` column is defined with a preferred
width of 36 charaters. The table object will use that information to
format the output accordingly. For example, a command like this:

```
$ ocm list clusters --columns id,external_id,name --managed
```

Will result in the following output:

```
ID                                EXTERNAL_ID                   NAME
1i6anlpc6278j4ok5nbp8ik69dl6h53j  9f2c1195-1f1b-4780-ae09-00f6  osde2e-hwlrn
1ku25di05s69u46bbnc0abihl9ig2e9a  155beb89-feec-4246-aab9-1592  osde2e-hxhfh
1lfklioadcqr5oeitfokqkavq4gir25l  e2eb5d92-f0d7-4077-b7b3-a2d8  osde2e-kp4sk
1lfklji54fhu3b64us3a62d9t9bju2r8  NONE                          osde2e-wfw97
1lfkljjopet5vkpnks33j65kb7pilao3  3e567572-f4fb-49cf-b25e-3196  osde2e-o9z8x
...
```

Note that this patch only modifies the `list clusters` command. Other
commands that write tables are still using the previous infrastructure.
That will be addressed in separate patches.

Related: https://issues.redhat.com/browse/SDA-4246