### PR TITLE
Don't remove config file on logout

### DIFF
--- a/cmd/ocm/account/orgs/cmd.go
+++ b/cmd/ocm/account/orgs/cmd.go
@@ -76,12 +76,12 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := cfg.Armed()
+	armed, reason, err := cfg.Armed()
 	if err != nil {
-		return fmt.Errorf("Can't check if tokens have expired: %v", err)
+		return err
 	}
 	if !armed {
-		return fmt.Errorf("Tokens have expired, run the 'login' command")
+		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
 	}
 
 	// Create the connection, and remember to close it:

--- a/cmd/ocm/account/quota/cmd.go
+++ b/cmd/ocm/account/quota/cmd.go
@@ -60,7 +60,6 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-
 	// Load the configuration file:
 	cfg, err := config.Load()
 	if err != nil {
@@ -71,12 +70,12 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := cfg.Armed()
+	armed, reason, err := cfg.Armed()
 	if err != nil {
-		return fmt.Errorf("Can't check if tokens have expired: %v", err)
+		return err
 	}
 	if !armed {
-		return fmt.Errorf("Tokens have expired, run the 'login' command")
+		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
 	}
 
 	// Create the connection, and remember to close it:

--- a/cmd/ocm/account/roles/cmd.go
+++ b/cmd/ocm/account/roles/cmd.go
@@ -67,12 +67,12 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := cfg.Armed()
+	armed, reason, err := cfg.Armed()
 	if err != nil {
-		return fmt.Errorf("Can't check if tokens have expired: %v", err)
+		return err
 	}
 	if !armed {
-		return fmt.Errorf("Tokens have expired, run the 'login' command")
+		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
 	}
 
 	// Create the connection, and remember to close it:

--- a/cmd/ocm/account/status/cmd.go
+++ b/cmd/ocm/account/status/cmd.go
@@ -62,12 +62,12 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := cfg.Armed()
+	armed, reason, err := cfg.Armed()
 	if err != nil {
-		return fmt.Errorf("Can't check if tokens have expired: %v", err)
+		return err
 	}
 	if !armed {
-		return fmt.Errorf("Tokens have expired, run the 'login' command")
+		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
 	}
 
 	// Create the connection, and remember to close it:

--- a/cmd/ocm/account/users/cmd.go
+++ b/cmd/ocm/account/users/cmd.go
@@ -84,12 +84,12 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := cfg.Armed()
+	armed, reason, err := cfg.Armed()
 	if err != nil {
-		return fmt.Errorf("Can't check if tokens have expired: %v", err)
+		return err
 	}
 	if !armed {
-		return fmt.Errorf("Tokens have expired, run the 'login' command")
+		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
 	}
 
 	// Create the connection, and remember to close it:

--- a/cmd/ocm/config/get/get.go
+++ b/cmd/ocm/config/get/get.go
@@ -48,14 +48,20 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
+	// Load the configuration file:
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("Can't load config file: %v", err)
 	}
+
+	// If the configuration file doesn't exist yet assume that all the configuration settings
+	// are empty:
 	if cfg == nil {
-		return fmt.Errorf("Not logged in, run the 'login' command")
+		fmt.Printf("\n")
+		return nil
 	}
 
+	// Print the value of the requested configuration setting:
 	switch argv[0] {
 	case "access_token":
 		fmt.Fprintf(os.Stdout, "%s\n", cfg.AccessToken)

--- a/cmd/ocm/config/set/set.go
+++ b/cmd/ocm/config/set/set.go
@@ -48,16 +48,21 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
+	// Load the configuration:
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("Can't load config file: %v", err)
 	}
-	if cfg == nil {
-		return fmt.Errorf("Not logged in, run the 'login' command")
-	}
-	value := argv[1]
 
-	switch argv[0] {
+	// Create an empty configuration if the configuration file doesn't exist:
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+
+	// Copy the value given in the command line to the configuration:
+	name := argv[0]
+	value := argv[1]
+	switch name {
 	case "access_token":
 		cfg.AccessToken = value
 	case "client_id":
@@ -83,6 +88,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Unknown setting")
 	}
 
+	// Save the configuration:
 	err = config.Save(cfg)
 	if err != nil {
 		return fmt.Errorf("Can't save config file: %v", err)

--- a/cmd/ocm/get/cmd.go
+++ b/cmd/ocm/get/cmd.go
@@ -70,12 +70,12 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, err := cfg.Armed()
+	armed, reason, err := cfg.Armed()
 	if err != nil {
-		return fmt.Errorf("Can't check if tokens have expired: %v", err)
+		return err
 	}
 	if !armed {
-		return fmt.Errorf("Tokens have expired, run the 'login' command")
+		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
 	}
 
 	// Create the connection:

--- a/cmd/ocm/logout/cmd.go
+++ b/cmd/ocm/logout/cmd.go
@@ -27,16 +27,25 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "logout",
 	Short: "Log out",
-	Long:  "Log out, removing the configuration file.",
+	Long:  "Log out, removing connection related variables from the config file.",
 	Args:  cobra.NoArgs,
 	RunE:  run,
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-	// Remove the configuration file:
-	err := config.Remove()
+	// Load the configuration file:
+	cfg, err := config.Load()
 	if err != nil {
-		return fmt.Errorf("Can't remove config file: %v", err)
+		return fmt.Errorf("can't load configuration file: %w", err)
+	}
+
+	// Remove all the login related settings from the configuration file:
+	cfg.Disarm()
+
+	// Save the configuration file:
+	err = config.Save(cfg)
+	if err != nil {
+		return fmt.Errorf("can't save configuration file: %w", err)
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+)
+
+var _ = Describe("Armed", func() {
+	It("Is armed if contains user name and password", func() {
+		config := &Config{
+			User:     "my-user",
+			Password: "my-password",
+			URL:      "http://my-server.example.com",
+			TokenURL: "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+
+	It("Is armed if contains client identifier and secret", func() {
+		config := &Config{
+			ClientID:     "my-client",
+			ClientSecret: "my-secret",
+			URL:          "http://my-server.example.com",
+			TokenURL:     "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+
+	It("Is armed if contains valid access token", func() {
+		config := &Config{
+			AccessToken: MakeTokenString("Bearer", 15*time.Minute),
+			URL:         "http://my-server.example.com",
+			TokenURL:    "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+
+	It("Is armed if contains valid refresh token", func() {
+		config := &Config{
+			AccessToken: MakeTokenString("Refresh", 10*time.Hour),
+			URL:         "http://my-server.example.com",
+			TokenURL:    "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+
+	It("Is armed if contains expired access token but valid refresh token", func() {
+		config := &Config{
+			AccessToken:  MakeTokenString("Access", -5*time.Minute),
+			RefreshToken: MakeTokenString("Refresh", 10*time.Hour),
+			URL:          "http://my-server.example.com",
+			TokenURL:     "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+
+	It("Is armed if contains valid access token but expired refresh token", func() {
+		config := &Config{
+			AccessToken:  MakeTokenString("Access", 15*time.Minute),
+			RefreshToken: MakeTokenString("Refresh", -10*time.Hour),
+			URL:          "http://my-server.example.com",
+			TokenURL:     "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+
+	It("Isn't armed if contains expired access token only", func() {
+		config := &Config{
+			AccessToken: MakeTokenString("Bearer", -5*time.Minute),
+			URL:         "http://my-server.example.com",
+			TokenURL:    "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeFalse())
+		Expect(reason).To(Equal("access token is expired"))
+	})
+
+	It("Isn't armed if contains expired refresh token only", func() {
+		config := &Config{
+			RefreshToken: MakeTokenString("Refresh", -5*time.Minute),
+			URL:          "http://my-server.example.com",
+			TokenURL:     "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeFalse())
+		Expect(reason).To(Equal("refresh token is expired"))
+	})
+
+	It("Isn't armed if contains expired access and refresh tokens", func() {
+		config := &Config{
+			AccessToken:  MakeTokenString("Access", -5*time.Minute),
+			RefreshToken: MakeTokenString("Refresh", -5*time.Minute),
+			URL:          "http://my-server.example.com",
+			TokenURL:     "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeFalse())
+		Expect(reason).To(Equal("access and refresh tokens are expired"))
+	})
+
+	It("Isn't armed if it contains user name but no password", func() {
+		config := &Config{
+			User:     "my-user",
+			URL:      "http://my-server.example.com",
+			TokenURL: "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeFalse())
+		Expect(reason).To(Equal("credentials aren't set"))
+	})
+
+	It("Isn't armed if it contains client identifier but no secret", func() {
+		config := &Config{
+			ClientID: "my-client",
+			URL:      "http://my-server.example.com",
+			TokenURL: "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeFalse())
+		Expect(reason).To(Equal("credentials aren't set"))
+	})
+
+	It("Isn't armed if empty", func() {
+		config := &Config{}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeFalse())
+		Expect(reason).To(Equal("credentials aren't set"))
+	})
+})

--- a/pkg/config/main_test.go
+++ b/pkg/config/main_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo" // nolint
+	. "github.com/onsi/gomega" // nolint
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config")
+}

--- a/pkg/ocm/connection.go
+++ b/pkg/ocm/connection.go
@@ -45,27 +45,27 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 		// Load the configuration file:
 		b.cfg, err = config.Load()
 		if err != nil {
-			err = fmt.Errorf("Failed to load config file: %v", err)
-			return result, err
+			return
 		}
 		if b.cfg == nil {
 			err = fmt.Errorf("Not logged in, run the 'login' command")
-			return result, err
+			return
 		}
 	}
 
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, err := b.cfg.Armed()
+	armed, reason, err := b.cfg.Armed()
 	if err != nil {
-		return result, fmt.Errorf("Can't check if tokens have expired: %v", err)
+		return
 	}
 	if !armed {
-		return result, fmt.Errorf("Tokens have expired, run the 'login' command")
+		err = fmt.Errorf("not logged in, %s, run the 'login' command", reason)
+		return
 	}
 
 	result, err = b.cfg.Connection()
 	if err != nil {
-		return result, fmt.Errorf("Can't create connection: %v", err)
+		return
 	}
 
 	return

--- a/tests/get_test.go
+++ b/tests/get_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Get", func() {
 
 	})
 
-	When("Not logged in", func() {
+	When("Config file doesn't exist", func() {
 		It("Fails", func() {
 			getResult := NewCommand().
 				Args(
@@ -48,7 +48,19 @@ var _ = Describe("Get", func() {
 		})
 	})
 
-	When("Logged in", func() {
+	When("Config file doesn't contain valid credentials", func() {
+		It("Fails", func() {
+			getResult := NewCommand().
+				ConfigString(`{}`).
+				Args(
+					"get", "/api/my_service/v1/my_object",
+				).Run(ctx)
+			Expect(getResult.ExitCode()).ToNot(BeZero())
+			Expect(getResult.ErrString()).To(ContainSubstring("Not logged in"))
+		})
+	})
+
+	When("Config file contains valid credentials", func() {
 		var ssoServer *Server
 		var apiServer *Server
 		var config string

--- a/tests/logout_test.go
+++ b/tests/logout_test.go
@@ -18,9 +18,12 @@ package tests
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo" // nolint
 	. "github.com/onsi/gomega" // nolint
+
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
 )
 
 var _ = Describe("Logout", func() {
@@ -30,9 +33,82 @@ var _ = Describe("Logout", func() {
 		ctx = context.Background()
 	})
 
-	It("Removes the configuration file", func() {
-		result := NewCommand().ConfigString(`{}`).Args("logout").Run(ctx)
+	It("Doesn't remove configuration file", func() {
+		result := NewCommand().
+			ConfigString(`{}`).
+			Args("logout").
+			Run(ctx)
 		Expect(result.ExitCode()).To(BeZero())
-		Expect(result.ConfigFile()).To(BeEmpty())
+		Expect(result.ConfigFile()).ToNot(BeEmpty())
+	})
+
+	It("Removes tokens from configuration file", func() {
+		// Generate the tokens:
+		accessToken := MakeTokenString("Bearer", 15*time.Minute)
+		refreshToken := MakeTokenString("Refresh", 10*time.Hour)
+
+		// Run the command:
+		result := NewCommand().
+			ConfigString(
+				`{
+					"access_token": "{{ .accessToken }}",
+					"refresh_token": "{{ .refreshToken }}"
+				}`,
+				"accessToken", accessToken,
+				"refreshToken", refreshToken,
+			).
+			Args("logout").
+			Run(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+		Expect(result.ConfigString()).To(MatchJSON(`{}`))
+	})
+
+	It("Removes client credentials from configuration file", func() {
+		result := NewCommand().
+			ConfigString(`{
+				"client_id": "my_client",
+				"client_secret": "my_secret"
+			}`).
+			Args("logout").
+			Run(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+		Expect(result.ConfigString()).To(MatchJSON(`{}`))
+	})
+
+	It("Removes URLs from configuration file", func() {
+		result := NewCommand().
+			ConfigString(`{
+				"token_url": "http://my-sso.example.com",
+				"url": "http://my-api.example.com"
+			}`).
+			Args("logout").
+			Run(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+		Expect(result.ConfigString()).To(MatchJSON(`{}`))
+	})
+
+	It("Removes scopes from configuration file", func() {
+		result := NewCommand().
+			ConfigString(`{
+				"scopes": [
+					"my_scope",
+					"your_scope"
+				]
+			}`).
+			Args("logout").
+			Run(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+		Expect(result.ConfigString()).To(MatchJSON(`{}`))
+	})
+
+	It("Removes insecure flag from configuration file", func() {
+		result := NewCommand().
+			ConfigString(`{
+				"insecure": true
+			}`).
+			Args("logout").
+			Run(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+		Expect(result.ConfigString()).To(MatchJSON(`{}`))
 	})
 })

--- a/tests/token_test.go
+++ b/tests/token_test.go
@@ -48,7 +48,9 @@ var _ = Describe("Token", func() {
 				ConfigString(
 					`{
 						"refresh_token": "{{ .refreshToken }}",
-						"access_token": "{{ .accessToken }}"
+						"access_token": "{{ .accessToken }}",
+						"url": "http://my-server.example.com",
+						"token_url": "http://my-sso.example.com"
 					}`,
 					"accessToken", accessToken,
 					"refreshToken", refreshToken,


### PR DESCRIPTION
Currently the `ocm logout` command removes the `$HOME/.ocm.json`
configuration file.  his makes it difficult to have settings that
aren't related to authentication. For example, we want to introduce a
setting to enable/disable paging, and we would like to have that
persisted in the configuration file so that the user doesn't need to
change it after each logout. To allow that this patch changes the
`logout` command so that instead of removing the configuration file it
removes all the login related settings.