### PR TITLE
Add `pager` configuration setting

### DIFF
--- a/cmd/ocm/config/get/get.go
+++ b/cmd/ocm/config/get/get.go
@@ -81,6 +81,8 @@ func run(cmd *cobra.Command, argv []string) error {
 		fmt.Fprintf(os.Stdout, "%s\n", cfg.TokenURL)
 	case "url":
 		fmt.Fprintf(os.Stdout, "%s\n", cfg.URL)
+	case "pager":
+		fmt.Fprintf(os.Stdout, "%s\n", cfg.Pager)
 	default:
 		return fmt.Errorf("Unknown setting")
 	}

--- a/cmd/ocm/config/set/set.go
+++ b/cmd/ocm/config/set/set.go
@@ -84,6 +84,8 @@ func run(cmd *cobra.Command, argv []string) error {
 		cfg.TokenURL = value
 	case "url":
 		cfg.URL = value
+	case "pager":
+		cfg.Pager = value
 	default:
 		return fmt.Errorf("Unknown setting")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	TokenURL     string   `json:"token_url,omitempty" doc:"OpenID token URL."`
 	URL          string   `json:"url,omitempty" doc:"URL of the API gateway. The value can be the complete URL or an alias. The valid aliases are 'production', 'staging' and 'integration'."`
 	User         string   `json:"user,omitempty" doc:"User name."`
+	Pager        string   `json:"pager,omitempty" doc:"Pager command, for example 'less'. If empty no pager will be used."`
 }
 
 // Load loads the configuration from the configuration file. If the configuration file doesn't exist

--- a/tests/logout_test.go
+++ b/tests/logout_test.go
@@ -111,4 +111,17 @@ var _ = Describe("Logout", func() {
 		Expect(result.ExitCode()).To(BeZero())
 		Expect(result.ConfigString()).To(MatchJSON(`{}`))
 	})
+
+	It("Doesn't remove settings not related to authentication", func() {
+		result := NewCommand().
+			ConfigString(`{
+				"pager": "less"
+			}`).
+			Args("logout").
+			Run(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+		Expect(result.ConfigString()).To(MatchJSON(`{
+			"pager": "less"
+		}`))
+	})
 })


### PR DESCRIPTION
This patch adds a new `pager` configuration setting that will be used in
the future to configure the command to use to display output page by
page.