### PR TITLE
Use pager command for `list clusters`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -271,6 +271,7 @@ func tokenUsable(token string, margin time.Duration) (usable bool, err error) {
 		return
 	}
 	if !expires {
+		usable = true
 		return
 	}
 	if left >= margin {

--- a/pkg/ocm/connection.go
+++ b/pkg/ocm/connection.go
@@ -59,7 +59,7 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 		return
 	}
 	if !armed {
-		err = fmt.Errorf("not logged in, %s, run the 'login' command", reason)
+		err = fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
 		return
 	}
 

--- a/pkg/output/printer.go
+++ b/pkg/output/printer.go
@@ -1,0 +1,202 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+)
+
+// PrinterBuilder contains the data and logic needed to create new printers.
+type PrinterBuilder struct {
+	writer io.Writer
+	pager  string
+}
+
+// Printer knows how to write output text.
+type Printer struct {
+	writer      io.Writer
+	pagerCmd    *exec.Cmd
+	pagerStop   chan int
+	pagerReader *os.File
+	pagerWriter *os.File
+}
+
+// Make sure that we implement the io.Writer interface.
+var _ io.Writer = (*Printer)(nil)
+
+// NewPrinter creates a builder that can then be used to configure and create a printer.
+func NewPrinter() *PrinterBuilder {
+	return &PrinterBuilder{
+		writer: os.Stdout,
+	}
+}
+
+// Writer sets the writer where the printer will write. It will usually be a file or the standard
+// output fo the process. This is mandatory.
+func (b *PrinterBuilder) Writer(value io.Writer) *PrinterBuilder {
+	b.writer = value
+	return b
+}
+
+// Pager indicates the command that will be used to display output page by page. If empty no pager
+// will be used.
+func (b *PrinterBuilder) Pager(value string) *PrinterBuilder {
+	b.pager = value
+	return b
+}
+
+// Build uses the data stored in the builder to create a new printer.
+func (b *PrinterBuilder) Build(ctx context.Context) (result *Printer, err error) {
+	// Check parameters:
+	if b.writer == nil {
+		err = fmt.Errorf("writer is mandatory")
+		return
+	}
+
+	// Check if there pager tool is available:
+	pagerEnabled, pagerPath, pagerArgs, err := b.pagerCommand()
+	if err != nil {
+		return
+	}
+
+	// Check if the output is a TTY:
+	isTTY, err := b.isTTY(b.writer)
+	if err != nil {
+		return
+	}
+
+	// If paging is enabled, a pager is available and the output is a TTY, then start that pager
+	// in the background and redirect all the output to it:
+	writer := b.writer
+	var pagerCmd *exec.Cmd
+	var pagerStop chan int
+	var pagerReader, pagerWriter *os.File
+	if pagerEnabled && isTTY {
+		// Create a pipe to connect us to the pager process:
+		pagerReader, pagerWriter, err = os.Pipe()
+		if err != nil {
+			return
+		}
+
+		// Start the pager process so that it reads from the pipe and writes to our output:
+		pagerCmd = exec.Command(pagerPath, pagerArgs...)
+		pagerCmd.Stdin = pagerReader
+		pagerCmd.Stdout = writer
+		err = pagerCmd.Start()
+		if err != nil {
+			pagerReader.Close()
+			pagerWriter.Close()
+			return
+		}
+
+		// The pager process may finish at any time, even before we finish writing, because
+		// the user may explicitly finish, with the `q` command or with Ctr-C. That means
+		// that we need to wait for the process to finish in a separate goroutine. When it
+		// finishes we then need to close both ends of the pipe. That will result in
+		// returning an error to any goroutine that tries to write to it, and that will in
+		// turn result in gracefully ending that goroutine.
+		pagerStop = make(chan int)
+		go func() {
+			pagerCmd.Wait()
+			pagerReader.Close()
+			pagerWriter.Close()
+			close(pagerStop)
+		}()
+	}
+
+	// Create and populate the object:
+	result = &Printer{
+		writer:      writer,
+		pagerCmd:    pagerCmd,
+		pagerStop:   pagerStop,
+		pagerReader: pagerReader,
+		pagerWriter: pagerWriter,
+	}
+
+	return
+}
+
+// isTTY checks if the given writer is a TTY.
+func (b *PrinterBuilder) isTTY(writer io.Writer) (result bool, err error) {
+	file, ok := writer.(*os.File)
+	if ok {
+		result = isatty.IsTerminal(file.Fd())
+	}
+	return
+}
+
+// pagerCommand checks if the pager command specified in the configuration is available and
+// translates it into a command path and a list of arguments for easy use with the exec.Command
+// function. It will return an empty command path and nil in the list of arguments if the pager
+// isn't available.
+func (b *PrinterBuilder) pagerCommand() (enabled bool, path string, args []string, err error) {
+	// If the pager command is empty then paging is disabled:
+	if b.pager == "" {
+		return
+	}
+
+	// Separate the command name and the arguments:
+	chunks := strings.Split(b.pager, " ")
+	if len(chunks) == 0 {
+		return
+	}
+
+	// Check if the command is available:
+	path, err = exec.LookPath(chunks[0])
+	if errors.Is(err, exec.ErrNotFound) {
+		err = nil
+		return
+	}
+
+	// If we are here then the command is enabled:
+	enabled = true
+	args = chunks[1:]
+
+	return
+}
+
+// Write is the implementation of the io.Writer interface.
+func (p *Printer) Write(b []byte) (n int, err error) {
+	writer := p.writer
+	if p.pagerWriter != nil {
+		writer = p.pagerWriter
+	}
+	n, err = writer.Write(b)
+	return
+}
+
+// Close releases all the resources used by the printer.
+func (p *Printer) Close() error {
+	// At this point we assume that we finished writing. But the pager may still be running. To
+	// make sure that it stops we need to close both ends of the pipe. Then we need to wait till
+	// the goroutine that is responsible for waiting the process has finished, as otherwise we
+	// may leave a zombie process around.
+	if p.pagerCmd != nil {
+		p.pagerReader.Close()
+		p.pagerWriter.Close()
+		<-p.pagerStop
+	}
+	return nil
+}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -59,13 +59,14 @@ func FindMapValue(data map[string]interface{}, key string) (string, bool) {
 }
 
 // PrintPadded turns an array into a padded string and outputs it into the given writer.
-func PrintPadded(w io.Writer, columns []string, padding []int) {
+func PrintPadded(w io.Writer, columns []string, padding []int) error {
 	updated := updateRowPad(columns, padding)
 	var finalString string
 	for _, str := range updated {
 		finalString = fmt.Sprint(finalString, str)
 	}
-	fmt.Fprint(w, finalString+"\n")
+	_, err := fmt.Fprint(w, finalString+"\n")
+	return err
 }
 
 func updateRowPad(columnList []string, columnPad []int) []string {

--- a/tests/list_clusters_test.go
+++ b/tests/list_clusters_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo"       // nolint
+	. "github.com/onsi/gomega"       // nolint
+	. "github.com/onsi/gomega/ghttp" // nolint
+
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+)
+
+var _ = Describe("List clusters", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		// Create a context:
+		ctx = context.Background()
+
+	})
+
+	When("Config file doesn't exist", func() {
+		It("Fails", func() {
+			getResult := NewCommand().
+				Args(
+					"list", "clusters",
+				).Run(ctx)
+			Expect(getResult.ExitCode()).ToNot(BeZero())
+			Expect(getResult.ErrString()).To(ContainSubstring("Not logged in"))
+		})
+	})
+
+	When("Config file doesn't contain valid credentials", func() {
+		It("Fails", func() {
+			getResult := NewCommand().
+				ConfigString(`{}`).
+				Args(
+					"list", "clusters",
+				).Run(ctx)
+			Expect(getResult.ExitCode()).ToNot(BeZero())
+			Expect(getResult.ErrString()).To(ContainSubstring("Not logged in"))
+		})
+	})
+
+	When("Config file contains valid credentials", func() {
+		var ssoServer *Server
+		var apiServer *Server
+		var config string
+
+		BeforeEach(func() {
+			// Create the servers:
+			ssoServer = MakeTCPServer()
+			apiServer = MakeTCPServer()
+
+			// Create the token:
+			accessToken := MakeTokenString("Bearer", 15*time.Minute)
+
+			// Prepare the server:
+			ssoServer.AppendHandlers(
+				RespondWithAccessToken(accessToken),
+			)
+
+			// Login:
+			result := NewCommand().
+				Args(
+					"login",
+					"--client-id", "my-client",
+					"--client-secret", "my-secret",
+					"--token-url", ssoServer.URL(),
+					"--url", apiServer.URL(),
+				).
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			config = result.ConfigString()
+		})
+
+		AfterEach(func() {
+			// Close the servers:
+			ssoServer.Close()
+			apiServer.Close()
+		})
+
+		It("Writes the clusters returned by the server", func() {
+			// Prepare the server:
+			apiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind": "ClusterList",
+						"page": 1,
+						"size": 2,
+						"total": 2,
+						"items": [
+							{
+								"kind": "Cluster",
+								"id": "123",
+								"href": "/api/clusters_mgmt/v1/clusters/123",
+								"name": "my_cluster",
+								"api": {
+									"url": "http://api.my-cluster.com"
+								},
+								"openshift_version": "4.7",
+								"product": {
+									"kind": "ProductLink",
+									"id": "osd",
+									"href": "/api/clusters_mgmt/v1/products/osd"
+								},
+								"cloud_provider": {
+									"kind": "CloudProviderLink",
+									"id": "aws",
+									"href": "/api/clusters_mgmt/v1/cloud_providers/aws"
+								},
+								"cloud_provider": {
+									"kind": "CloudProviderLink",
+									"id": "aws",
+									"href": "/api/clusters_mgmt/v1/cloud_providers/aws"
+								},
+								"region": {
+									"kind": "CloudRegion",
+									"id": "us-east-1",
+									"href": "/api/clusters_mgmt/v1/cloud_providers/aws/us-east-1"
+								},
+								"state": "ready"
+							},
+							{
+								"kind": "Cluster",
+								"id": "456",
+								"href": "/api/clusters_mgmt/v1/clusters/456",
+								"name": "your_cluster",
+								"api": {
+									"url": "http://api.your-cluster.com"
+								},
+								"openshift_version": "4.8",
+								"product": {
+									"kind": "ProductLink",
+									"id": "ocp",
+									"href": "/api/clusters_mgmt/v1/products/ocp"
+								},
+								"cloud_provider": {
+									"kind": "CloudProviderLink",
+									"id": "gcp",
+									"href": "/api/clusters_mgmt/v1/cloud_providers/gcp"
+								},
+								"region": {
+									"kind": "CloudRegion",
+									"id": "us-west1",
+									"href": "/api/clusters_mgmt/v1/cloud_providers/gcp/us-west1"
+								},
+								"state": "installing"
+							}
+						]
+					}`,
+				),
+			)
+
+			// Run the command:
+			result := NewCommand().
+				ConfigString(config).
+				Args("list", "clusters").
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			Expect(result.ErrString()).To(BeEmpty())
+			lines := result.OutLines()
+			Expect(lines).To(HaveLen(3))
+			Expect(lines[0]).To(MatchRegexp(
+				`^\s*ID\s+NAME\s+API URL\s+OPENSHIFT_VERSION\s+PRODUCT ID\s+CLOUD_PROVIDER\s+REGION ID\s+STATE\s*$`,
+			))
+			Expect(lines[1]).To(MatchRegexp(
+				`^\s*123\s+my_cluster\s+http://api.my-cluster.com\s+4\.7\s+osd\s+aws\s+us-east-1\s+ready\s*$`,
+			))
+			Expect(lines[2]).To(MatchRegexp(
+				`^\s*456\s+your_cluster\s+http://api.your-cluster.com\s+4\.8\s+ocp\s+gcp\s+us-west1\s+installing\s*$`,
+			))
+		})
+	})
+})

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -204,6 +204,21 @@ func (r *CommandResult) OutString() string {
 	return string(r.out)
 }
 
+// OutLines returns the standard output of the CLI command as an array of strings.
+func (r *CommandResult) OutLines() []string {
+	// Split the output into lines:
+	lines := strings.Split(string(r.out), "\n")
+
+	// If there is a blank line at the end remove it:
+	count := len(lines)
+	if count > 0 && lines[count-1] == "" {
+		lines = lines[0 : count-1]
+	}
+
+	// Return the lines:
+	return lines
+}
+
 // Err returns the standard errour output of the CLI command.
 func (r *CommandResult) ErrString() string {
 	return string(r.err)


### PR DESCRIPTION
This patch changes the `list clusters` command so that it uses the
a pager command (if available) to display the results page by page.

This will not be enabled by default. To enable it set the `pager` config
variable to the command that you wish to use. For example, to use the
`less` command:

```
$ ocm config set pager 'less -F'
```

Related: https://issues.redhat.com/browse/SDA-4280