### PR TITLE
Add printer table for organizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.orig
 *.patch
 *.rej
+/.vscode
 /ocm
 /ocm-darwin-amd64
 /ocm-darwin-amd64.sha256sum

--- a/pkg/output/tables/orgs.yaml
+++ b/pkg/output/tables/orgs.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+columns:
+- name: id
+  header: ID
+  width: 27
+- name: name
+  header: NAME
+  width: 64


### PR DESCRIPTION
This patch changes the `list orgs` command so that it uses a printer
table.