### PR TITLE
Add table for plugins

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,7 +64,7 @@ func Load() (cfg *Config, err error) {
 	}
 	_, err = os.Stat(file)
 	if os.IsNotExist(err) {
-		cfg = nil
+		cfg = &Config{}
 		err = nil
 		return
 	}
@@ -78,7 +78,7 @@ func Load() (cfg *Config, err error) {
 		err = fmt.Errorf("can't read config file '%s': %v", file, err)
 		return
 	}
-	cfg = new(Config)
+	cfg = &Config{}
 	err = json.Unmarshal(data, cfg)
 	if err != nil {
 		err = fmt.Errorf("can't parse config file '%s': %v", file, err)

--- a/pkg/output/tables/plugins.yaml
+++ b/pkg/output/tables/plugins.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+columns:
+- name: name
+  header: NAME
+  width: 20
+- name: path
+  header: PATH
+  width: 30


### PR DESCRIPTION
This patch changes the `plugin list` command so that it uses a table for
displaying results.