### PR TITLE
Use table for `account orgs`

### DIFF
--- a/cmd/ocm/account/orgs/cmd.go
+++ b/cmd/ocm/account/orgs/cmd.go
@@ -17,27 +17,25 @@ limitations under the License.
 package orgs
 
 import (
-	"bytes"
-	"encoding/json"
+	"context"
 	"fmt"
 	"os"
-	"strings"
 
+	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/config"
-	table "github.com/openshift-online/ocm-cli/pkg/table"
-	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift-online/ocm-cli/pkg/output"
 )
 
 var args struct {
 	columns   string
 	parameter []string
-	padding   int
+	header    []string
 }
 
-// Cmd ...
 var Cmd = &cobra.Command{
 	Use:   "orgs",
 	Short: "List organizations.",
@@ -50,124 +48,91 @@ func init() {
 	// Add flags to rootCmd:
 	fs := Cmd.Flags()
 	arguments.AddParameterFlag(fs, &args.parameter)
+	arguments.AddHeaderFlag(fs, &args.header)
 	fs.StringVar(
 		&args.columns,
 		"columns",
-		"id,name", // Default value gets assigned later as connection is needed.
-		"Organization identifier. Defaults to the organization of the current user.",
-	)
-	fs.IntVar(
-		&args.padding,
-		"padding",
-		45,
-		"Takes padding for custom columns, default to 45.",
+		"id,name",
+		"Comma separated list of columns to display.",
 	)
 }
 
 func run(cmd *cobra.Command, argv []string) error {
+	// Create a context:
+	ctx := context.Background()
 
-	// Load the configuration file:
+	// Load the configuration:
 	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
-	}
-	if cfg == nil {
-		return fmt.Errorf("Not logged in, run the 'login' command")
-	}
-
-	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, reason, err := cfg.Armed()
 	if err != nil {
 		return err
 	}
-	if !armed {
-		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
-	}
 
-	// Create the connection, and remember to close it:
-	connection, err := cfg.Connection()
+	// Create the client for the OCM API:
+	connection, err := ocm.NewConnection().Build()
 	if err != nil {
-		return fmt.Errorf("Can't create connection: %v", err)
+		return err
 	}
 	defer connection.Close()
 
-	// Indices
-	pageIndex := 1
-	pageSize := 100
+	// Create the output printer:
+	printer, err := output.NewPrinter().
+		Writer(os.Stdout).
+		Pager(cfg.Pager).
+		Build(ctx)
+	if err != nil {
+		return err
+	}
+	defer printer.Close()
 
-	// Setting column names and padding size
-	// Update our column name displaying variable:
-	args.columns = strings.Replace(args.columns, " ", "", -1)
-	colUpper := strings.ToUpper(args.columns)
-	colUpper = strings.Replace(colUpper, ".", " ", -1)
-	columnNames := strings.Split(colUpper, ",")
-	paddingByColumn := []int{29, 65, 70}
-	if args.columns != "id,name" {
-		paddingByColumn = []int{args.padding}
+	// Create the output table:
+	table, err := printer.NewTable().
+		Name("orgs").
+		Columns(args.columns).
+		Build(ctx)
+	if err != nil {
+		return err
+	}
+	defer table.Close()
+
+	// Write the header row:
+	err = table.WriteHeaders()
+	if err != nil {
+		return err
 	}
 
-	// Print Header Row:
-	table.PrintPadded(os.Stdout, columnNames, paddingByColumn)
+	// Create the request. Note that this request can be created outside of the loop and used
+	// for all iterations just changing the values of the `size` and `page` parameters.
+	request := connection.AccountsMgmt().V1().Organizations().List()
+	arguments.ApplyParameterFlag(request, args.parameter)
+	arguments.ApplyHeaderFlag(request, args.header)
 
+	// Send the request till we receive a page with less items than requested:
+	size := 100
+	index := 1
 	for {
-		// Next page request:
-		request := connection.AccountsMgmt().V1().Organizations().
-			List().
-			Page(pageIndex).
-			Size(pageSize)
-
-		// Apply parameters
-		arguments.ApplyParameterFlag(request, args.parameter)
-
-		// Fetch next page
-		orgList, err := request.Send()
+		// Fetch the next page:
+		request.Size(size)
+		request.Page(index)
+		response, err := request.Send()
 		if err != nil {
-			return fmt.Errorf("Failed to retrieve organization list: %v", err)
+			return fmt.Errorf("can't retrieve organizations: %w", err)
 		}
 
-		// Display organization information
-		orgList.Items().Each(func(org *amv1.Organization) bool {
-			// String to output marshal -
-			// Map used to parse Organization data -
-			// Writer to body variable:
-			var body string
-			var jsonBody map[string]interface{}
-			boddyBuffer := bytes.NewBufferString(body)
-
-			// Write Organization data to body variable:
-			err := amv1.MarshalOrganization(org, boddyBuffer)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to marshal organization into byte buffer: %s\n", err)
-				os.Exit(1)
-			}
-
-			// Get JSON from Organization bytes
-			err = json.Unmarshal(boddyBuffer.Bytes(), &jsonBody)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to turn organization bytes into JSON map: %s\n", err)
-				os.Exit(1)
-			}
-
-			// Loop through wanted columns and populate an organization instance
-			iter := strings.Split(args.columns, ",")
-			thisOrg := []string{}
-			for _, element := range iter {
-				value, status := table.FindMapValue(jsonBody, element)
-				if !status {
-					value = "NONE"
-				}
-				thisOrg = append(thisOrg, value)
-			}
-			table.PrintPadded(os.Stdout, thisOrg, paddingByColumn)
-			return true
+		// Display the items of the fetched page:
+		response.Items().Each(func(org *amv1.Organization) bool {
+			err = table.WriteRow(org)
+			return err == nil
 		})
-
-		// Break if we reach last page
-		if orgList.Size() < pageSize {
+		if err != nil {
 			break
 		}
 
-		pageIndex++
+		// If the number of fetched items is less than requested, then this was the last
+		// page, otherwise process the next one:
+		if response.Size() < size {
+			break
+		}
+		index++
 	}
 
 	return nil

--- a/cmd/ocm/list/org/cmd.go
+++ b/cmd/ocm/list/org/cmd.go
@@ -104,7 +104,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	// for all iterations just changing the values of the `size` and `page` parameters.
 	request := connection.AccountsMgmt().V1().Organizations().List()
 	arguments.ApplyParameterFlag(request, args.parameter)
-	arguments.ApplyHeaderFlag(request, args.parameter)
+	arguments.ApplyHeaderFlag(request, args.header)
 
 	// Send the request till we receive a page with less items than requested:
 	size := 100

--- a/tests/account_orgs_test.go
+++ b/tests/account_orgs_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo"       // nolint
+	. "github.com/onsi/gomega"       // nolint
+	. "github.com/onsi/gomega/ghttp" // nolint
+
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+)
+
+var _ = Describe("Account orgs", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		// Create a context:
+		ctx = context.Background()
+
+	})
+
+	When("Config file doesn't exist", func() {
+		It("Fails", func() {
+			getResult := NewCommand().
+				Args(
+					"account", "orgs",
+				).Run(ctx)
+			Expect(getResult.ExitCode()).ToNot(BeZero())
+			Expect(getResult.ErrString()).To(ContainSubstring("Not logged in"))
+		})
+	})
+
+	When("Config file doesn't contain valid credentials", func() {
+		It("Fails", func() {
+			getResult := NewCommand().
+				ConfigString(`{}`).
+				Args(
+					"list", "orgs",
+				).Run(ctx)
+			Expect(getResult.ExitCode()).ToNot(BeZero())
+			Expect(getResult.ErrString()).To(ContainSubstring("Not logged in"))
+		})
+	})
+
+	When("Config file contains valid credentials", func() {
+		var ssoServer *Server
+		var apiServer *Server
+		var config string
+
+		BeforeEach(func() {
+			// Create the servers:
+			ssoServer = MakeTCPServer()
+			apiServer = MakeTCPServer()
+
+			// Create the token:
+			accessToken := MakeTokenString("Bearer", 15*time.Minute)
+
+			// Prepare the server:
+			ssoServer.AppendHandlers(
+				RespondWithAccessToken(accessToken),
+			)
+
+			// Login:
+			result := NewCommand().
+				Args(
+					"login",
+					"--client-id", "my-client",
+					"--client-secret", "my-secret",
+					"--token-url", ssoServer.URL(),
+					"--url", apiServer.URL(),
+				).
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			config = result.ConfigString()
+		})
+
+		AfterEach(func() {
+			// Close the servers:
+			ssoServer.Close()
+			apiServer.Close()
+		})
+
+		It("Writes the organizations returned by the server", func() {
+			// Prepare the server:
+			apiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind": "OrganizationList",
+						"page": 1,
+						"size": 2,
+						"total": 2,
+						"items": [
+							{
+								"kind": "Organization",
+								"id": "123",
+								"href": "/api/accounts_mgmt/v1/organizations/123",
+								"name": "my_org"
+							},
+							{
+								"kind": "Organization",
+								"id": "456",
+								"href": "/api/accounts_mgmt/v1/organizations/456",
+								"name": "your_org"
+							}
+						]
+					}`,
+				),
+			)
+
+			// Run the command:
+			result := NewCommand().
+				ConfigString(config).
+				Args("list", "orgs").
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			Expect(result.ErrString()).To(BeEmpty())
+			lines := result.OutLines()
+			Expect(lines).To(HaveLen(3))
+			Expect(lines[0]).To(MatchRegexp(
+				`^\s*ID\s+NAME\s*$`,
+			))
+			Expect(lines[1]).To(MatchRegexp(
+				`^\s*123\s+my_org\s*$`,
+			))
+			Expect(lines[2]).To(MatchRegexp(
+				`^\s*456\s+your_org\s*$`,
+			))
+		})
+	})
+})


### PR DESCRIPTION
This patch changes the `account orgs` command so that it uses a table to
display output.

Note that this command is currently identical to `list orgs`, it should
probably be changed or removed.