### PR TITLE
Add column width learning

### DIFF
--- a/cmd/ocm/account/orgs/cmd.go
+++ b/cmd/ocm/account/orgs/cmd.go
@@ -120,7 +120,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 		// Display the items of the fetched page:
 		response.Items().Each(func(org *amv1.Organization) bool {
-			err = table.WriteRow(org)
+			err = table.WriteObject(org)
 			return err == nil
 		})
 		if err != nil {

--- a/cmd/ocm/list/addon/cmd.go
+++ b/cmd/ocm/list/addon/cmd.go
@@ -130,6 +130,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	if len(clusterAddOns) == 0 {
 		fmt.Printf("There are no add-ons installed on cluster '%s'", clusterKey)
+		return nil
 	}
 
 	// Write the column headers:
@@ -140,7 +141,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	// Write the rows:
 	for _, clusterAddOn := range clusterAddOns {
-		err = table.WriteRow(clusterAddOn)
+		err = table.WriteObject(clusterAddOn)
 		if err != nil {
 			break
 		}

--- a/cmd/ocm/list/cluster/cmd.go
+++ b/cmd/ocm/list/cluster/cmd.go
@@ -198,7 +198,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 		// Display the items of the fetched page:
 		response.Items().Each(func(cluster *v1.Cluster) bool {
-			err = table.WriteRow(cluster)
+			err = table.WriteObject(cluster)
 			return err == nil
 		})
 		if err != nil {

--- a/cmd/ocm/list/idp/cmd.go
+++ b/cmd/ocm/list/idp/cmd.go
@@ -140,7 +140,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	// Write the rows:
 	for _, idp := range idps {
-		err = table.WriteRow(idp)
+		err = table.WriteObject(idp)
 		if err != nil {
 			break
 		}

--- a/cmd/ocm/list/org/cmd.go
+++ b/cmd/ocm/list/org/cmd.go
@@ -120,7 +120,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 		// Display the items of the fetched page:
 		response.Items().Each(func(org *amv1.Organization) bool {
-			err = table.WriteRow(org)
+			err = table.WriteObject(org)
 			return err == nil
 		})
 		if err != nil {

--- a/cmd/ocm/plugin/list/cmd.go
+++ b/cmd/ocm/plugin/list/cmd.go
@@ -110,7 +110,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	// Write the rows:
 	for _, plugin := range plugins {
-		err = table.WriteRow(plugin)
+		err = table.WriteObject(plugin)
 		if err != nil {
 			break
 		}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a
 	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 // indirect
 	golang.org/x/sys v0.0.0-20210603125802-9665404d3644 // indirect
-	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
+	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/apimachinery v0.18.5
 )

--- a/pkg/output/tables/endpoints.yaml
+++ b/pkg/output/tables/endpoints.yaml
@@ -14,4 +14,10 @@
 # limitations under the License.
 #
 
-# Empty on purpose.
+columns:
+- name: id
+  header: ID
+- name: api.url
+  header: API ENDPOINT
+- name: api.listening
+  header: PRIVATE

--- a/pkg/output/tables/idps.yaml
+++ b/pkg/output/tables/idps.yaml
@@ -14,13 +14,4 @@
 # limitations under the License.
 #
 
-columns:
-- name: name
-  header: NAME
-  width: 20
-- name: type
-  header: TYPE
-  width: 6
-- name: auth_url
-  header: AUTH URL
-  width: 120
+# Empty on purpose.

--- a/pkg/output/tables/ingresses.yaml
+++ b/pkg/output/tables/ingresses.yaml
@@ -14,4 +14,14 @@
 # limitations under the License.
 #
 
-# Empty on purpose.
+columns:
+- name: id
+  header: ID
+- name: application_router
+  header: APPLICATION ROUTER
+- name: listening
+  header: PRIVATE
+- name: default
+  header: DEFAULT
+- name: route_selectors
+  header: ROUTE SELECTORS

--- a/pkg/output/tables/plugins.yaml
+++ b/pkg/output/tables/plugins.yaml
@@ -14,10 +14,4 @@
 # limitations under the License.
 #
 
-columns:
-- name: name
-  header: NAME
-  width: 20
-- name: path
-  header: PATH
-  width: 30
+# Empty on purpose.


### PR DESCRIPTION
This patch changes the `output.Table` object so that it accumulates the
first rows of the output (one hundred by default) in order to learn how
to display the values.

Currently that learning is very basic: it adjusts the width of the
columns to not waste space, and only does it for columsn that don't have
a width explicitly defined in the corresponding YAML file.

This works well usually, but may product wrong results if the data in
the first one hundred rows is very different from the data in the
following rows.