### PR TITLE
Fix cluster lookup

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -110,31 +110,95 @@ func IsValidClusterKey(clusterKey string) bool {
 	return clusterKeyRE.MatchString(clusterKey)
 }
 
-func GetCluster(connection *sdk.Connection, clusterKey string) (*cmv1.Cluster, error) {
-	search := fmt.Sprintf("(display_name = '%s' "+
-		"or cluster_id = '%s' "+
-		"or external_cluster_id = '%s' )"+
-		"and status = 'Active'",
-		clusterKey, clusterKey, clusterKey)
-	response, err := connection.AccountsMgmt().V1().Subscriptions().List().Search(search).Size(1).Send()
+func GetCluster(connection *sdk.Connection, key string) (cluster *cmv1.Cluster, err error) {
+	// Prepare the resources that we will be using:
+	subsResource := connection.AccountsMgmt().V1().Subscriptions()
+	clustersResource := connection.ClustersMgmt().V1().Clusters()
+
+	// Try to find a matching subscription:
+	subsSearch := fmt.Sprintf(
+		"(display_name = '%s' or cluster_id = '%s' or external_cluster_id = '%s') and "+
+			"status in ('Reserved', 'Active')",
+		key, key, key,
+	)
+	subsListResponse, err := subsResource.List().
+		Search(subsSearch).
+		Size(1).
+		Send()
 	if err != nil {
-		return nil, fmt.Errorf("Can't retrieve cluster for key '%s': %v", clusterKey, err)
+		err = fmt.Errorf("Can't retrieve subscription for key '%s': %v", key, err)
+		return
 	}
 
-	switch response.Total() {
-	case 0:
-		return nil, fmt.Errorf("There is no cluster with identifier or name '%s'", clusterKey)
-	case 1:
-		subs := response.Items().Slice()
-		clusterID := subs[0].ClusterID()
-		clusterResponse, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Get().Send()
-		if err != nil {
-			return nil, fmt.Errorf("Can't retrieve cluster for key '%s': %v", clusterKey, err)
+	// If there is exactly one matching subscription then return the corresponding cluster:
+	subsTotal := subsListResponse.Total()
+	if subsTotal == 1 {
+		id, ok := subsListResponse.Items().Slice()[0].GetClusterID()
+		if ok {
+			var clusterGetResponse *cmv1.ClusterGetResponse
+			clusterGetResponse, err = clustersResource.Cluster(id).Get().
+				Send()
+			if err != nil {
+				err = fmt.Errorf(
+					"Can't retrieve cluster for key '%s': %v",
+					key, err,
+				)
+				return
+			}
+			cluster = clusterGetResponse.Body()
+			return
 		}
-		return clusterResponse.Body(), nil
-	default:
-		return nil, fmt.Errorf("There are %d clusters with identifier or name '%s'", response.Total(), clusterKey)
 	}
+
+	// If there are multiple subscriptions that match the cluster then we should report it as
+	// an error:
+	if subsTotal > 1 {
+		err = fmt.Errorf(
+			"There are %d subscriptions with cluster identifier or name '%s'",
+			subsTotal, key,
+		)
+		return
+	}
+
+	// If we are here then no subscription matches the passed key. It may still be possible that
+	// the cluster exists but it is not reporting metrics, so it will not have the external
+	// identifier in the accounts management service. To find those clusters we need to check
+	// directly in the clusters management service.
+	clustersSearch := fmt.Sprintf(
+		"id = '%s' or name = '%s' or external_id = '%s'",
+		key, key, key,
+	)
+	clustersListResponse, err := clustersResource.List().
+		Search(clustersSearch).
+		Size(1).
+		Send()
+	if err != nil {
+		err = fmt.Errorf("Can't retrieve clusters for key '%s': %v", key, err)
+		return
+	}
+
+	// If there is exactly one cluster matching then return it:
+	clustersTotal := clustersListResponse.Total()
+	if clustersTotal == 1 {
+		cluster = clustersListResponse.Items().Slice()[0]
+		return
+	}
+
+	// If there are multiple matching clusters then we should report it as an error:
+	if clustersTotal > 1 {
+		err = fmt.Errorf(
+			"There are %d clusters with identifier or name '%s'",
+			clustersTotal, key,
+		)
+		return
+	}
+
+	// If we are here then there are no subscriptions or clusters matching the passed key:
+	err = fmt.Errorf(
+		"There are no subscriptions or clusters with identifier or name '%s'",
+		key,
+	)
+	return
 }
 
 func CreateCluster(cmv1Client *cmv1.Client, config Spec, dryRun bool) (*cmv1.Cluster, error) {

--- a/tests/describe_cluster_test.go
+++ b/tests/describe_cluster_test.go
@@ -98,6 +98,16 @@ var _ = Describe("Describe clusters", func() {
 						"items": []
 					  }`,
 				),
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind": "ClusterList",
+						"page": 1,
+						"size": 0,
+						"total": 0,
+						"items": []
+					  }`,
+				),
 			)
 
 			// Run the command:
@@ -106,7 +116,9 @@ var _ = Describe("Describe clusters", func() {
 				Args("describe", "cluster", "nonexist").
 				Run(ctx)
 			Expect(result.ExitCode()).ToNot(BeZero())
-			Expect(result.ErrString()).To(ContainSubstring("There is no cluster with identifier or name"))
+			Expect(result.ErrString()).To(ContainSubstring(
+				"There are no subscriptions or clusters with identifier or name 'nonexist'",
+			))
 		})
 
 		It("Describe an exist cluster", func() {


### PR DESCRIPTION
This patch changes the cluster lookup logic so that that it will search
for subscriptions in `Reserved` and `Active` state, and so that it will
look in the clusters collection when there are no matching results in
the subscriptions collection.

Related: https://issues.redhat.com/browse/SDA-4458