### PR TITLE
Update login URL for upcoming move to console.redhat.com

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,7 +66,7 @@ $ ocm completion --help
 The first step to use the tool is to log-in with your OpenShift Cluster Manager
 offline access token which you can get below:
 
-https://cloud.redhat.com/openshift/token[https://cloud.redhat.com/openshift/token]
+https://console.redhat.com/openshift/token[https://console.redhat.com/openshift/token]
 
 To do that use the `login` command:
 

--- a/cmd/ocm/login/cmd.go
+++ b/cmd/ocm/login/cmd.go
@@ -47,7 +47,7 @@ var urlAliases = map[string]string{
 }
 
 // #nosec G101
-const uiTokenPage = "https://cloud.redhat.com/openshift/token"
+const uiTokenPage = "https://console.redhat.com/openshift/token"
 
 var args struct {
 	tokenURL     string
@@ -177,7 +177,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		fmt.Fprintf(
 			os.Stderr,
 			"Authenticating with a user name and password is deprecated. To avoid "+
-				"this warning go to 'https://cloud.redhat.com/openshift/token' "+
+				"this warning go to 'https://console.redhat.com/openshift/token' "+
 				"to obtain your offline access token and then login using the "+
 				"'--token' option.\n",
 		)


### PR DESCRIPTION
The new URL already works so it's safe to merge & release this, and since users take time to upgrade the CLI, better sooner IMHO.

related to https://issues.redhat.com/browse/OSDOCS-2290