### PR TITLE
Update the RPM build instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -435,6 +435,7 @@ CLI for the Red Hat OpenShift Cluster Manager
 %setup
 
 %build
+PATH="${PATH}:${HOME}/go/bin"
 make
 
 %install


### PR DESCRIPTION
In order to build the RPM it is necessary to add the `${HOME}/go/bin`
directory to the path, as there is where `go get ...` installs the
`go-bindata` tool.

Related: https://issues.redhat.com/browse/SDA-4671