### PR TITLE
User friendly message when offline token is no longer valid

### DIFF
--- a/cmd/ocm/login/cmd.go
+++ b/cmd/ocm/login/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift-online/ocm-cli/pkg/config"
+	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
 const (
@@ -46,9 +47,6 @@ var urlAliases = map[string]string{
 	"int":         integrationURL,
 }
 
-// #nosec G101
-const uiTokenPage = "https://console.redhat.com/openshift/token"
-
 var args struct {
 	tokenURL     string
 	clientID     string
@@ -66,7 +64,8 @@ var Cmd = &cobra.Command{
 	Use:   "login",
 	Short: "Log in",
 	Long: "Log in, saving the credentials to the configuration file.\n" +
-		"The recommend way is using '--token', which you can obtain at: " + uiTokenPage,
+		"The recommend way is using '--token', which you can obtain at: " +
+		urls.OfflineTokenPage,
 	Args: cobra.NoArgs,
 	RunE: run,
 }
@@ -167,7 +166,7 @@ func run(cmd *cobra.Command, argv []string) error {
 				"'--password', or '--client-id' and '--client-secret'.\n"+
 				"You can obtain a token at: %s .\n"+
 				"See 'ocm login --help' for full help.\n",
-			uiTokenPage,
+			urls.OfflineTokenPage,
 		)
 		os.Exit(1)
 	}
@@ -177,9 +176,9 @@ func run(cmd *cobra.Command, argv []string) error {
 		fmt.Fprintf(
 			os.Stderr,
 			"Authenticating with a user name and password is deprecated. To avoid "+
-				"this warning go to 'https://console.redhat.com/openshift/token' "+
-				"to obtain your offline access token and then login using the "+
-				"'--token' option.\n",
+				"this warning go to '%s' to obtain your offline access token "+
+				"and then login using the '--token' option.\n",
+			urls.OfflineTokenPage,
 		)
 	}
 

--- a/pkg/urls/well_known.go
+++ b/pkg/urls/well_known.go
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains constants for well known URLs.
+
+package urls
+
+// OfflineTokenPage is the URL of the page used to generate offline access tokens.
+const OfflineTokenPage = "https://console.redhat.com/openshift/token" // #nosec G101

--- a/tests/token_test.go
+++ b/tests/token_test.go
@@ -56,7 +56,6 @@ var _ = Describe("Token", func() {
 					"refreshToken", refreshToken,
 				).
 				Arg("token")
-
 		})
 
 		It("Displays current access token", func() {

--- a/tests/whoami_test.go
+++ b/tests/whoami_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/golang-jwt/jwt"
+
+	. "github.com/onsi/ginkgo"                         // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+)
+
+var _ = Describe("Whoami", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		// Create a context:
+		ctx = context.Background()
+	})
+
+	When("Offline user session not found", func() {
+		var ssoServer *Server
+		var apiServer *Server
+
+		BeforeEach(func() {
+			// Create the servers:
+			ssoServer = MakeTCPServer()
+			apiServer = MakeTCPServer()
+
+			// Prepare the server:
+			ssoServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusBadRequest,
+					`{
+						"error": "invalid_grant",
+						"error_description": "Offline user session not found"
+					}`,
+				),
+			)
+		})
+
+		AfterEach(func() {
+			// Close the servers:
+			ssoServer.Close()
+			apiServer.Close()
+		})
+
+		It("Writes user friendly message", func() {
+			// Create a valid offline token:
+			tokenObject := MakeTokenObject(
+				jwt.MapClaims{
+					"typ": "Offline",
+					"exp": nil,
+				},
+			)
+			tokenString := tokenObject.Raw
+
+			// Prepare the SSO server so that it will respond saying that the offline
+			// session doesn't exist. This is something that happens some times in
+			// `sso.redhat.com` when the servers are restarted.
+			ssoServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusBadRequest, `{
+						"error_code": "invalid_grant",
+						"error_message": "Offline user session not found"
+					}`,
+				),
+			)
+
+			// Run the command:
+			whoamiResult := NewCommand().
+				ConfigString(
+					`{
+						"client_id": "cloud-services",
+						"insecure": true,
+						"refresh_token": "{{ .Token }}",
+						"scopes": [
+							"openid"
+						],
+						"token_url": "{{ .TokenURL }}",
+						"url": "{{ .URL }}"
+					}`,
+					"Token", tokenString,
+					"TokenURL", ssoServer.URL(),
+					"URL", apiServer.URL(),
+				).
+				Args("whoami").
+				Run(ctx)
+			Expect(whoamiResult.ExitCode()).ToNot(BeZero())
+			Expect(whoamiResult.ErrString()).To(Equal(
+				"Offline access token is no longer valid. Go to " +
+					"https://console.redhat.com/openshift/token to get a new " +
+					"one and then use the 'ocm login --token=...' command to " +
+					"log in with that new token.\n",
+			))
+		})
+	})
+})


### PR DESCRIPTION
This patch changes the CLI so that it will write the following message
when an operation fails because the offline access token is no longer
valid:

```
Offline access token is no longer valid. Go to
https://console.redhat.com/openshift/token to get a new
one and then use the 'ocm login --token=...' command to
log in with that new token.
```

Related: https://issues.redhat.com/browse/SDA-4686