### PR TITLE
Don't use `jq` for color output

### DIFF
--- a/cmd/ocm/get/cmd.go
+++ b/cmd/ocm/get/cmd.go
@@ -103,13 +103,13 @@ func run(cmd *cobra.Command, argv []string) error {
 	body := response.Bytes()
 	if status < 400 {
 		if args.single {
-			err = dump.Simple(os.Stdout, body)
+			err = dump.Single(os.Stdout, body)
 		} else {
 			err = dump.Pretty(os.Stdout, body)
 		}
 	} else {
 		if args.single {
-			err = dump.Simple(os.Stderr, body)
+			err = dump.Single(os.Stderr, body)
 		} else {
 			err = dump.Pretty(os.Stderr, body)
 		}

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/m1/go-generate-password v0.0.0-20191114193340-84682ecbc3fd
 	github.com/mattn/go-colorable v0.1.8 // indirect
-	github.com/mattn/go-isatty v0.0.12
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/nwidger/jsoncolor v0.3.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/openshift-online/ocm-sdk-go v0.1.204

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -377,6 +379,7 @@ github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -386,6 +389,7 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -423,6 +427,8 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/nwidger/jsoncolor v0.3.0 h1:VdTH8Dc0SJoq4pJ8pRxxFZW0/5Ng5akbN4YToCBJDSU=
+github.com/nwidger/jsoncolor v0.3.0/go.mod h1:Cs34umxLbJvgBMnVNVqhji9BhoT/N/KinHqZptQ7cf4=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -26,12 +26,12 @@ import (
 	"reflect"
 	"strings"
 
-	isatty "github.com/mattn/go-isatty"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/spf13/pflag"
 
 	"github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/debug"
+	"github.com/openshift-online/ocm-cli/pkg/output"
 )
 
 type FilePath string
@@ -269,7 +269,7 @@ func ApplyBodyFlag(request *sdk.Request, value string) error {
 		// #nosec G304
 		body, err = ioutil.ReadFile(value)
 	} else {
-		if isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stderr.Fd()) {
+		if output.IsTerminal(os.Stdin) && output.IsTerminal(os.Stderr) {
 			fmt.Fprintln(os.Stderr, "No --body file specified, reading request body from stdin:")
 		}
 		body, err = ioutil.ReadAll(os.Stdin)

--- a/pkg/output/terminal.go
+++ b/pkg/output/terminal.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// IsTerminal determines if the given writer is a terminal
+func IsTerminal(writer io.Writer) bool {
+	file, ok := writer.(*os.File)
+	if !ok {
+		return false
+	}
+	fd := int(file.Fd())
+	return term.IsTerminal(fd)
+}

--- a/tests/get_test.go
+++ b/tests/get_test.go
@@ -159,5 +159,91 @@ var _ = Describe("Get", func() {
 			Expect(result.ExitCode()).To(BeZero())
 			Expect(result.ErrString()).To(BeEmpty())
 		})
+
+		It("Indents by default", func() {
+			// Prepare the server:
+			apiServer.AppendHandlers(
+				CombineHandlers(
+					RespondWithJSON(http.StatusOK, `{
+						"my_field": "my_value",
+						"your_field": "your_value"
+					}`),
+				),
+			)
+
+			// Run the command:
+			result := NewCommand().
+				ConfigString(config).
+				Args(
+					"get",
+					"/api/my_service/v1/my_object",
+				).
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(result.OutString()).To(Equal(RemoveLeadingTabs(
+				`{
+				  "my_field": "my_value",
+				  "your_field": "your_value"
+				}
+				`,
+			)))
+		})
+
+		It("Honours the --single flag", func() {
+			// Prepare the server:
+			apiServer.AppendHandlers(
+				CombineHandlers(
+					RespondWithJSON(http.StatusOK, `{
+						"my_field": "my_value",
+						"your_field": "your_value"
+					}`),
+				),
+			)
+
+			// Run the command:
+			result := NewCommand().
+				ConfigString(config).
+				Args(
+					"get",
+					"--single",
+					"/api/my_service/v1/my_object",
+				).
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(result.OutString()).To(Equal(RemoveLeadingTabs(
+				`{"my_field":"my_value","your_field":"your_value"}
+				`,
+			)))
+		})
+
+		It("Preserves long integers", func() {
+			// Prepare the server:
+			apiServer.AppendHandlers(
+				CombineHandlers(
+					RespondWithJSON(http.StatusOK, `{
+						"my_field": 340282366920938463463374607431768211455
+					}`),
+				),
+			)
+
+			// Run the command:
+			result := NewCommand().
+				ConfigString(config).
+				Args(
+					"get",
+					"/api/my_service/v1/my_object",
+				).
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(result.OutString()).To(Equal(RemoveLeadingTabs(
+				`{
+				  "my_field": 340282366920938463463374607431768211455
+				}
+				`,
+			)))
+		})
 	})
 })


### PR DESCRIPTION
This patch changes the tool so that it doesn't rely on the `jq` tool in
order to produce color output.

The main reason to do this is to prevent incorrect handling of long
integers.

Related: https://github.com/openshift-online/ocm-cli/issues/295