### PR TITLE
Release 0.1.57

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -3,6 +3,20 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+== 0.1.57 Sep 22 2021
+
+- Replace `go-bindata` with Go 1.16 `embed.FS`. This has no practical
+  implication for users, but for developers it means that the project requires
+  Go 1.16.
+
+- Run tests using _GitHub_ actions instead of _Jenkins_. This increases the
+  platform coverate as tests now run in _Linux_, _MacOS_ and _Windows_.
+
+- Color output is now generated internally without requiring the installation
+  of the `jq` tool.
+
+- Show provisioning error code and message.
+
 == 0.1.56 Aug 25 2021
 
 - Use standard XDG configuration path for `ocm.json`.

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.56"
+const Version = "0.1.57"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Replace `go-bindata` with Go 1.16 `embed.FS`. This has no practical
  implication for users, but for developers it means that the project requires
  Go 1.16.

- Run tests using _GitHub_ actions instead of _Jenkins_. This increases the
  platform coverate as tests now run in _Linux_, _MacOS_ and _Windows_.

- Color output is now generated internally without requiring the installation
  of the `jq` tool.

- Show provisioning error code and message.