### PR TITLE
Fix publish release action

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -87,7 +87,7 @@ jobs:
         --header "Content-Type: application/json" \
         --header "Accept: application/json" \
         --url "https://api.github.com/repos/${{ github.repository }}/releases" \
-        --data @request.json \
+        --data-binary @request.json \
         --output response.json \
         --fail
 
@@ -103,7 +103,7 @@ jobs:
           --header "Content-Type: application/octect-stream" \
           --header "Accept: application/json" \
           --url "https://uploads.github.com/repos/${{ github.repository }}/releases/${id}/assets?name=${file}" \
-          --data "@assets/${file}" \
+          --data-binary "@assets/${file}" \
           --output response.json \
           --fail
         done


### PR DESCRIPTION
The action that publishes releases was uploading artifacts using the
`--data` option of the `curl` tool. That results in processing them as
ASCII and limits the size to approximately 4 MiB. The end result is that
the uploaded binaries don't work. This patch fixes that using the
`--data-binary` option instead.

Related: https://github.com/openshift-online/ocm-cli/issues/319