### PR TITLE
Fix binary names inside `.sha256` files

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -59,7 +59,9 @@ jobs:
            # Copy the generated binary to the assets directory and calculate
            # the digest:
            cp "ocm" "assets/ocm-${os}-${arch}"
-           sha256sum "ocm" > "assets/ocm-${os}-${arch}.sha256"
+           pushd assets
+             sha256sum "ocm-${os}-${arch}" > "ocm-${os}-${arch}.sha256"
+           popd
         }
 
         # Build for the supported operating systems and architectures:


### PR DESCRIPTION
Since the introduction of the `publish-release` action the `.sha256`
files contain incorrect file names. For example, the name of the actual
released binary for Linux and x86_64 is `ocm-linux-amd64` but the file
name inside the `.sha256` file is just `ocm`. This patch fixes that
issue.

Related: https://github.com/openshift-online/ocm-cli/issues/322