### PR TITLE
Fix bug - return exit code 1 when user creating is failed

### DIFF
--- a/cmd/ocm/create/user/cmd.go
+++ b/cmd/ocm/create/user/cmd.go
@@ -107,6 +107,8 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Group '%s' in cluster '%s' doesn't exist", args.group, clusterKey)
 	}
 
+	failedToAddUser := false
+	var usersFailed []string
 	for _, username := range strings.Split(users, ",") {
 		user, err := cmv1.NewUser().ID(username).Build()
 		if err != nil {
@@ -121,10 +123,16 @@ func run(cmd *cobra.Command, argv []string) error {
 			Send()
 		if err != nil {
 			fmt.Printf("Failed to add '%s' user '%s' to cluster '%s': %v\n", args.group, username, clusterKey, err)
+			failedToAddUser = true
+			usersFailed = append(usersFailed, username)
 			continue
 		}
 		fmt.Printf("Added '%s' user '%s' to cluster '%s'\n", args.group, username, clusterKey)
 	}
 
-	return nil
+	if failedToAddUser{
+		return fmt.Errorf("Failed to create the following users in group '%s': %s", args.group, strings.Join(usersFailed, ", "))
+	} else {
+		return nil
+	}
 }


### PR DESCRIPTION
Change the **cmd.go** file of the ``create user`` command to return exit
code 1 when user creating is failed with an existing username.
After the changes will be merged:
- When creating a user is failed the exit code will be 1.
- When creating multiple users, if one failed the exit status code
will be 1.

Solve Bug: SDA-4804
