### PR TITLE
OCM-CLI should not allow additional-trust-bundle as parameter

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -532,7 +532,7 @@ func shouldPromptForExistingVPC(areSubnetsProvided bool) bool {
 func wasClusterWideProxyReceived() bool {
 	return (args.clusterWideProxy.HTTPProxy != nil && *args.clusterWideProxy.HTTPProxy != "") ||
 		(args.clusterWideProxy.HTTPSProxy != nil && *args.clusterWideProxy.HTTPSProxy != "") ||
-		(args.clusterWideProxy.AdditionalTrustBundle != nil && *args.clusterWideProxy.AdditionalTrustBundle != "")
+		(args.clusterWideProxy.AdditionalTrustBundleFile != nil && *args.clusterWideProxy.AdditionalTrustBundleFile != "")
 }
 
 func isProxyEmpty() bool {
@@ -635,7 +635,8 @@ func promptClusterWideProxy(fs *pflag.FlagSet, connection *sdk.Connection, cmd *
 		if err != nil {
 			return err
 		}
-		fs.Set("additional-trust-bundle", string(cert))
+		args.clusterWideProxy.AdditionalTrustBundle = new(string)
+		*args.clusterWideProxy.AdditionalTrustBundle = string(cert)
 	}
 	if args.clusterWideProxy.AdditionalTrustBundleFile == nil {
 		args.clusterWideProxy.AdditionalTrustBundle = nil

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -218,14 +218,6 @@ func AddClusterWideProxyFlags(fs *pflag.FlagSet, value *cluster.ClusterWideProxy
 			"added to the nodes' trusted certificate store.")
 
 	SetQuestion(fs, "additional-trust-bundle-file", "additional-trust-bundle-file:")
-
-	value.AdditionalTrustBundle = new(string)
-	fs.StringVar(
-		value.AdditionalTrustBundle,
-		"additional-trust-bundle",
-		"",
-		"A PEM-encoded X.509 certificate bundle that will be "+
-			"added to the nodes' trusted certificate store.")
 }
 
 // AddAutoscalingFlags adds the --enable-autoscaling --min-replicas and --max-replicas flags


### PR DESCRIPTION
Signed-off-by: Tzvika Avni <tavni@redhat.com>

https://issues.redhat.com/browse/SDA-5389