### PR TITLE
There should be readable error message when create a ccs cluster with invalid --https-proxy value

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -603,7 +603,7 @@ func promptClusterWideProxy(fs *pflag.FlagSet, connection *sdk.Connection, cmd *
 		} else {
 			err := utils.IsURL(*args.clusterWideProxy.HTTPSProxy)
 			if err != nil {
-				return err
+				return fmt.Errorf("Invalid https-proxy value '%s'", *args.clusterWideProxy.HTTPSProxy)
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Tzvika Avni <tavni@redhat.com>

https://issues.redhat.com/browse/SDA-5392