### PR TITLE
Release 0.1.61

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,17 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+## 0.1.61 Feb 1 2022
+
+- Add STS to `describe cluster` output.
+- Add BYOPC flag to `describe cluster` command.
+- Support BYO-VPC cluster creation flags.
+- Support cluster-wide proxy during cluster creation and update.
+- Don't allow additional trust bundle as parameter.
+- Add more URLs to expander.
+- Readable error message when creating a CCS cluster with invalid
+  `--htts-proxy` value.
+
 ## 0.1.60 Dec 3 2021
 
 This version doesn't contain changes to the functionality, only to the

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.60"
+const Version = "0.1.61"


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Add STS to `describe cluster` output.
- Add BYOPC flag to `describe cluster` command.
- Support BYO-VPC cluster creation flags.
- Support cluster-wide proxy during cluster creation and update.
- Don't allow additional trust bundle as parameter.
- Add more URLs to expander.
- Readable error message when creating a CCS cluster with invalid
  `--htts-proxy` value.
