### PR TITLE
Only show relevant regions in interactive cluster create

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -261,6 +261,12 @@ func getRegionOptions(connection *sdk.Connection) ([]arguments.Option, error) {
 	}
 	options := []arguments.Option{}
 	for _, region := range regions {
+		if !args.ccs.Enabled && region.CCSOnly() {
+			continue
+		}
+		if args.multiAZ && !region.SupportsMultiAZ() {
+			continue
+		}
 		// `enabled` flag only affects Red Hat infra. All regions enabled on CCS.
 		if args.ccs.Enabled || region.Enabled() {
 			options = append(options, arguments.Option{


### PR DESCRIPTION
When a user selects non-CCS or multi-AZ, we should not list regions that
are incompatible with their selection.
Refs: https://issues.redhat.com/browse/SDA-4369