### PR TITLE
It should fail to create a cluster with proxy atrribute but no --use-existing-vpc

### DIFF
--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -157,22 +157,7 @@ func CheckIgnoredCCSFlags(ccs cluster.CCS) error {
 	return nil
 }
 
-// CheckIgnoredExistingVPCFlags errors if --subnet-ids flag is used without --use-existing-vpc.
-func CheckIgnoredExistingVPCFlags(existingVPC cluster.ExistingVPC) error {
-	if !existingVPC.Enabled && existingVPC.SubnetIDs != "" {
-		return fmt.Errorf("subnet-ids flag is meaningless without --use-existing-vpc")
-	}
-	return nil
-}
-
 func AddExistingVPCFlags(fs *pflag.FlagSet, value *cluster.ExistingVPC) {
-	fs.BoolVar(
-		&value.Enabled,
-		"use-existing-vpc",
-		false,
-		"Bring your own Virtual Private Network settings.",
-	)
-	SetQuestion(fs, "use-existing-vpc", "Install into an existing VPC:")
 
 	fs.StringVar(
 		&value.SubnetIDs,
@@ -190,39 +175,7 @@ func AddExistingVPCFlags(fs *pflag.FlagSet, value *cluster.ExistingVPC) {
 	)
 }
 
-// CheckIgnoredClusterWideProxyFlags errors if --http-proxy, --https-proxy or additional-trust-bundle
-// attributes were used without --cluster-wide-proxy
-func CheckIgnoredClusterWideProxyFlags(proxy cluster.ClusterWideProxy) error {
-	if !proxy.Enabled {
-		bad := []string{}
-		if proxy.HTTPProxy != nil && *proxy.HTTPProxy != "" {
-			bad = append(bad, "--http-proxy")
-		}
-		if proxy.HTTPSProxy != nil && *proxy.HTTPSProxy != "" {
-			bad = append(bad, "--https-proxy")
-		}
-		if proxy.AdditionalTrustBundleFile != nil && *proxy.AdditionalTrustBundleFile != "" {
-			bad = append(bad, "--additional-trust-bundle-file")
-		}
-		if len(bad) == 1 {
-			return fmt.Errorf("%s flag is meaningless without --cluster-wide-proxy", bad[0])
-		} else if len(bad) > 1 {
-			return fmt.Errorf("%s flags are meaningless without --cluster-wide-proxy",
-				strings.Join(bad, ", "))
-		}
-	}
-	return nil
-}
-
 func AddClusterWideProxyFlags(fs *pflag.FlagSet, value *cluster.ClusterWideProxy) {
-	fs.BoolVar(
-		&value.Enabled,
-		"cluster-wide-proxy",
-		false,
-		"The cluster-wide proxy definition for your cluster.",
-	)
-	SetQuestion(fs, "cluster-wide-proxy", "Use cluster-wide proxy:")
-
 	value.HTTPProxy = new(string)
 	fs.StringVar(
 		value.HTTPProxy,

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -322,22 +322,21 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec, dryRun bool) (*cmv1.Clu
 		default:
 			return nil, fmt.Errorf("Unexpected CCS provider %q", config.Provider)
 		}
-	}
-
-	//cluster-wide proxy
-	if config.ClusterWideProxy.HTTPProxy != nil || config.ClusterWideProxy.HTTPSProxy != nil {
-		proxyBuilder := cmv1.NewProxy()
-		if config.ClusterWideProxy.HTTPProxy != nil {
-			proxyBuilder.HTTPProxy(*config.ClusterWideProxy.HTTPProxy)
+		//cluster-wide proxy
+		if config.ClusterWideProxy.Enabled {
+			proxyBuilder := cmv1.NewProxy()
+			if config.ClusterWideProxy.HTTPProxy != nil && len(*config.ClusterWideProxy.HTTPProxy) != 0 {
+				proxyBuilder.HTTPProxy(*config.ClusterWideProxy.HTTPProxy)
+			}
+			if config.ClusterWideProxy.HTTPSProxy != nil && len(*config.ClusterWideProxy.HTTPSProxy) != 0 {
+				proxyBuilder.HTTPSProxy(*config.ClusterWideProxy.HTTPSProxy)
+			}
+			clusterBuilder = clusterBuilder.Proxy(proxyBuilder)
 		}
-		if config.ClusterWideProxy.HTTPSProxy != nil {
-			proxyBuilder.HTTPSProxy(*config.ClusterWideProxy.HTTPSProxy)
-		}
-		clusterBuilder = clusterBuilder.Proxy(proxyBuilder)
-	}
 
-	if config.ClusterWideProxy.AdditionalTrustBundle != nil {
-		clusterBuilder = clusterBuilder.AdditionalTrustBundle(*config.ClusterWideProxy.AdditionalTrustBundle)
+		if config.ClusterWideProxy.AdditionalTrustBundle != nil {
+			clusterBuilder = clusterBuilder.AdditionalTrustBundle(*config.ClusterWideProxy.AdditionalTrustBundle)
+		}
 	}
 
 	if config.ComputeMachineType != "" || config.ComputeNodes > 0 || len(config.ExistingVPC.AvailabilityZones) > 0 ||


### PR DESCRIPTION
Signed-off-by: Tzvika Avni <tavni@redhat.com>

https://issues.redhat.com/browse/SDA-5450

updated code to be similar to ROSA. Removed --use-existing-vpc and --cluster-wide-proxy flags.
The following are examples of valid requests and the expected results:

example 1:
./ocm create cluster vpctest20 --region us-west-1  --aws-account-id xxx --aws-access-key-id yyy --aws-secret-access-key zzz  --provider aws  -i
? CCS: Yes
? Multiple AZ: No
? OpenShift version: 4.9.18
? Compute machine type: r5.24xlarge
? Enable autoscaling: No
? Compute nodes: 2
? Install into an existing VPC (optional): Yes
? Subnet IDs (optional): subnet-0b12660243ad390a9 (us-west-1a), subnet-0a0210c16c5df930a (us-west-1a)
? Use cluster-wide proxy (optional): Yes
? HTTP Proxy (optional): http://ee.com/
? HTTPS Proxy (optional): https://yy.com/
? Additional trust bundle file path 

example 2:
./ocm create cluster vpctest20 --region us-west-1  --aws-account-id xxx --aws-access-key-id yyy --aws-secret-access-key zzz  --provider aws  --ccs --subnet-ids subnet-03e869efd028d8e0b,subnet-0321d3f933c6a18a4 --http-proxy http://ww.com --https-proxy https://rr.com/ --additional-trust-bundle-file /home/tavni/additional_trust_bundle.pem
the request is sent to the cs with subnets, availabilty zone and proxy values

example 3:
./ocm create cluster vpctest20 --region us-west-1  --aws-account-id xxx --aws-access-key-id yyy  --aws-secret-access-key zzz   --provider aws  --ccs --http-proxy http://aa.com/ 
Error: Failed to create cluster: unable to create cluster: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is 'b032fb3c-ee7c-46a1-9814-bf74d2602562': cluster_wide_proxy is only supported if subnetIDs exist

example 4:
./ocm create cluster vpctest20 --aws-access-key-id yyy --aws-secret-access-key zzz  --region us-west-1  --aws-account-id xxx  --provider aws  --ccs --http-proxy http://aa.com/ -i
? Multiple AZ: No
? OpenShift version: 4.9.18
? Compute machine type: r5.24xlarge
? Enable autoscaling: No
? Compute nodes: 2
? Subnet IDs (optional): subnet-0b12660243ad390a9 (us-west-1a), subnet-0a0210c16c5df930a (us-west-1a)
? HTTP Proxy: http://aa.com/
? HTTPS Proxy (optional): 
? Additional trust bundle file path (optional):

exmaple 5:
./ocm create cluster vpctest20 --region us-west-1  --aws-account-id xxx --aws-access-key-id yyy  --aws-secret-access-key zzz --provider aws  --ccs --subnet-ids subnet-03e869efd028d8e0b,subnet-0321d3f933c6a18a4
request with subnetIDs sent to cs

exmaple 6:
./ocm create cluster vpctest20 --region us-west-1  --aws-account-id xxx --aws-access-key-id yyy  --aws-secret-access-key zzz --provider aws  --ccs --subnet-ids subnet-03e869efd028d8e0b,subnet-0321d3f933c6a18a4 -i
? Multiple AZ: No
? OpenShift version: 4.9.18
? Compute machine type: r5.24xlarge
? Enable autoscaling: No
? Compute nodes: 2
? Use cluster-wide proxy: Yes
? HTTP Proxy (optional):