### PR TITLE
Add extra scopes support for OpenID IDP

### DIFF
--- a/cmd/ocm/create/idp/cmd.go
+++ b/cmd/ocm/create/idp/cmd.go
@@ -54,10 +54,11 @@ var args struct {
 	ldapEmails       string
 
 	// OpenID
-	openidIssuerURL string
-	openidEmail     string
-	openidName      string
-	openidUsername  string
+	openidIssuerURL   string
+	openidEmail       string
+	openidName        string
+	openidUsername    string
+	openidExtraScopes string
 
 	// HTPasswd
 	htpasswdUsername string
@@ -225,6 +226,12 @@ func init() {
 		"username-claims",
 		"",
 		"OpenID: List of claims to use as the preferred username when provisioning a user.\n",
+	)
+	flags.StringVar(
+		&args.openidExtraScopes,
+		"extra-scopes",
+		"",
+		"OpenID: List of extra scopes to request when provisioning a user.\n",
 	)
 
 	// HTPasswd

--- a/cmd/ocm/create/idp/openid.go
+++ b/cmd/ocm/create/idp/openid.go
@@ -32,6 +32,7 @@ func buildOpenidIdp(cluster *cmv1.Cluster, idpName string) (idpBuilder cmv1.Iden
 	email := args.openidEmail
 	name := args.openidName
 	username := args.openidUsername
+	extraScopes := args.openidExtraScopes
 
 	isInteractive := clientID == "" || clientSecret == "" || issuerURL == "" ||
 		(email == "" && name == "" && username == "")
@@ -107,6 +108,16 @@ func buildOpenidIdp(cluster *cmv1.Cluster, idpName string) (idpBuilder cmv1.Iden
 				return idpBuilder, errors.New("Expected a list of claims to use as the preferred username")
 			}
 		}
+
+		if extraScopes == "" {
+			prompt := &survey.Input{
+				Message: "Extra scopes to request:",
+			}
+			err = survey.AskOne(prompt, &extraScopes)
+			if err != nil {
+				return idpBuilder, errors.New("Expected a list of extra scopes to request")
+			}
+		}
 	}
 
 	if email == "" && name == "" && username == "" {
@@ -144,7 +155,8 @@ func buildOpenidIdp(cluster *cmv1.Cluster, idpName string) (idpBuilder cmv1.Iden
 		ClientID(clientID).
 		ClientSecret(clientSecret).
 		Issuer(issuerURL).
-		Claims(openIDClaims)
+		Claims(openIDClaims).
+		ExtraScopes(extraScopes)
 
 	// Create new IDP with OpenID provider
 	idpBuilder.


### PR DESCRIPTION
Add `--extra-scopes` to `ocm create idp` to support creating OpenID IDP with extra scopes.