### PR TITLE
Pretty print JSON arrays

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
-	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a
 	golang.org/x/term v0.0.0-20210503060354-a79de5458b56
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/apimachinery v0.23.1
 )
@@ -61,7 +61,6 @@ require (
 	golang.org/x/crypto v0.0.0-20211215165025-cf75a172585e // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
-	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -742,8 +742,6 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 github.com/zgalor/weberr v0.6.0/go.mod h1:cqK89mj84q3PRgqQXQFWJDzCorOd8xOtov/ulOnqDwc=
 gitlab.com/c0b/go-ordered-json v0.0.0-20171130231205-49bbdab258c2/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
-gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a h1:DxppxFKRqJ8WD6oJ3+ZXKDY0iMONQDl5UTg2aTyHh8k=
-gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=

--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/nwidger/jsoncolor"
 	"github.com/openshift-online/ocm-cli/pkg/output"
-	"gitlab.com/c0b/go-ordered-json"
 )
 
 // Pretty dumps the given data to the given stream so that it looks pretty. If the data is a valid
@@ -34,8 +33,8 @@ func Pretty(stream io.Writer, body []byte) error {
 	if len(body) == 0 {
 		return nil
 	}
-	data := ordered.NewOrderedMap()
-	err := json.Unmarshal(body, data)
+	var data interface{}
+	err := json.Unmarshal(body, &data)
 	if err != nil {
 		return dumpBytes(stream, body)
 	}
@@ -64,8 +63,8 @@ func Single(stream io.Writer, body []byte) error {
 	if len(body) == 0 {
 		return nil
 	}
-	data := ordered.NewOrderedMap()
-	err := json.Unmarshal(body, data)
+	var data interface{}
+	err := json.Unmarshal(body, &data)
 	if err != nil {
 		return dumpBytes(stream, body)
 	}


### PR DESCRIPTION
Currently the JSON output is only pretty printed when it is an object.
Arrays aren't pretty printed. This patch fixes that.