### PR TITLE
Correct the doc URLs for IDP creation

### DIFF
--- a/cmd/ocm/create/idp/ldap.go
+++ b/cmd/ocm/create/idp/ldap.go
@@ -32,8 +32,8 @@ func buildLdapIdp(_ *cmv1.Cluster, idpName string) (idpBuilder cmv1.IdentityProv
 
 	if isInteractive {
 		fmt.Println("To use LDAP as an identity provider, you must first register the application:")
-		instructionsURL := "https://docs.openshift.com/dedicated/4/authentication/" +
-			"identity_providers/configuring-ldap-identity-provider.html"
+		instructionsURL := "https://docs.openshift.com/dedicated/osd_install_access_delete_cluster/" +
+			"config-identity-providers.html#config-ldap-idp_config-identity-providers"
 		fmt.Println("* Open the following URL:", instructionsURL)
 		fmt.Println("* Follow the instructions to register your application")
 

--- a/cmd/ocm/create/idp/openid.go
+++ b/cmd/ocm/create/idp/openid.go
@@ -38,8 +38,8 @@ func buildOpenidIdp(cluster *cmv1.Cluster, idpName string) (idpBuilder cmv1.Iden
 
 	if isInteractive {
 		fmt.Println("To use OpenID as an identity provider, you must first register the application:")
-		instructionsURL := "https://docs.openshift.com/dedicated/4/authentication/" +
-			"identity_providers/configuring-oidc-identity-provider.html"
+		instructionsURL := "https://docs.openshift.com/dedicated/osd_install_access_delete_cluster/" +
+			"config-identity-providers.html#config-openid-idp_config-identity-providers"
 		fmt.Println("* Open the following URL:", instructionsURL)
 		fmt.Println("* Follow the instructions to register your application")
 


### PR DESCRIPTION
I observed that the current interactive wizard for adding an IDP points to a documentation URL that doesn't redirect to IDP-specific documentation (it just lands at the OSD docs homepage).

This PR updates the links to point to the correct documentation resources.
