### PR TITLE
network: Ensure there is no default network type

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -220,7 +220,7 @@ func init() {
 	fs.StringVar(
 		&args.networkType,
 		"network-type",
-		c.NetworkTypeSDN,
+		"",
 		fmt.Sprintf("The main controller responsible for rendering the core networking components. "+
 			"Allowed values are %s and %s", c.NetworkTypeSDN, c.NetworkTypeOVN),
 	)


### PR DESCRIPTION
Since the network type is defined in the API based on the OpenShift
version, we remove the client-side default. If the user overrides the
hidden flag, the API will ensure that the user has the required
capabilities to use the non-default network type for that version.