### PR TITLE
Add validation when user creates a cluster only with no-proxy (non-interacitve mode)

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -688,6 +688,11 @@ func promptClusterWideProxy() error {
 			}
 		}
 	}
+	if (args.clusterWideProxy.HTTPProxy != nil && *args.clusterWideProxy.HTTPProxy == "") &&
+		(args.clusterWideProxy.HTTPSProxy != nil && *args.clusterWideProxy.HTTPSProxy == "") &&
+		(args.clusterWideProxy.NoProxy != nil && *args.clusterWideProxy.NoProxy != "") {
+		return fmt.Errorf("Expected at least one of the following: http-proxy, https-proxy")
+	}
 
 	// Get certificate contents
 	if args.clusterWideProxy.AdditionalTrustBundleFile != nil &&


### PR DESCRIPTION

Signed-off-by: Tzvika Avni <tavni@redhat.com>

SDA-6712