### PR TITLE
Add build artifact for darwin/arm64

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -86,6 +86,7 @@ jobs:
 
         # Build for the supported operating systems and architectures:
         build("darwin", "amd64")
+        build("darwin", "arm64")
         build("linux", "amd64")
         build("linux", "arm64")
         build("linux", "ppc64le")


### PR DESCRIPTION
Builds the ocm CLI for darwin/arm64 (mac m1)