### PR TITLE
Return the service cluster for HyperShift clusters with `ocm describe cluster`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.vscode
 /ocm
 /ocm-*
+/.idea

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/nwidger/jsoncolor v0.3.1
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.26.0
-	github.com/openshift-online/ocm-sdk-go v0.1.316
+	github.com/openshift-online/ocm-sdk-go v0.1.318
 	github.com/openshift/rosa v1.2.15
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
 github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
-github.com/openshift-online/ocm-sdk-go v0.1.316 h1:rBU+bW5fSqIk2xiTNRLpSgBsPxAC+kDYHKUWsxWDqCk=
-github.com/openshift-online/ocm-sdk-go v0.1.316/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
+github.com/openshift-online/ocm-sdk-go v0.1.318 h1:AbpyTVAWDSFK3KQt6MCEaZOo3wiTypNcg+gnIIkD17A=
+github.com/openshift-online/ocm-sdk-go v0.1.318/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/rosa v1.2.15 h1:rluxd6cVHTJtlqcqtZkCI0GltxuLA/Sxbf35pd+jqEM=
 github.com/openshift/rosa v1.2.15/go.mod h1:qwsOrRGX2xRjEtOpt0Xfxg8S4Ll8jF7iw3eHvALKKpc=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=

--- a/pkg/cluster/describe_test.go
+++ b/pkg/cluster/describe_test.go
@@ -1,0 +1,40 @@
+package cluster
+
+import (
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"testing"
+)
+
+// newTestCluster assembles a *cmv1.Cluster while handling the error to help out with inline test-case generation
+func newTestCluster(t *testing.T, cb *cmv1.ClusterBuilder) *cmv1.Cluster {
+	cluster, err := cb.Build()
+	if err != nil {
+		t.Fatalf("failed to build cluster: %s", err)
+	}
+
+	return cluster
+}
+
+func TestFindHyperShiftMgmtSvcClusters(t *testing.T) {
+	tests := []struct {
+		name         string
+		cluster      *cmv1.Cluster
+		expectedMgmt string
+		expectedSvc  string
+	}{
+		{
+			name:    "Not HyperShift",
+			cluster: newTestCluster(t, cmv1.NewCluster().Hypershift(cmv1.NewHypershift().Enabled(false))),
+		},
+	}
+
+	for _, test := range tests {
+		mgmt, svc := findHyperShiftMgmtSvcClusters(nil, test.cluster)
+		if test.expectedMgmt != mgmt {
+			t.Errorf("expected %s, got %s", test.expectedMgmt, mgmt)
+		}
+		if test.expectedSvc != svc {
+			t.Errorf("expected %s, got %s", test.expectedSvc, svc)
+		}
+	}
+}


### PR DESCRIPTION
When troubleshooting HyperShift clusters, sometimes it is important to inspect the relevant service cluster. This PR does this by essentially implementing:

```
❯ ocm get /api/osd_fleet_mgmt/v1/service_clusters -p search="id='$(ocm get /api/osd_fleet_mgmt/v1/management_clusters -p search="name='hs-mc-op846kea0'" | jq -r '.items[0].parent.id')'" | jq -r '.items[0].name'

hs-sc-op846kde0
```

Sample output:
```
❯ ocm describe cluster 21rrnvvf6rd4vdndl4lf3gie7mat0gna                                

ID:			21rrnvvf6rd4vdndl4lf3gie7mat0gna
External ID:		d61a016b-dd48-4f96-ac27-dc9a1b1f7b63
...
Management Cluster:     hs-mc-jsui4ri9g
Service Cluster:        hs-sc-op846kde0

```