### PR TITLE
Add display name to describe output

### DIFF
--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -165,10 +165,12 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 		"ID:			%s\n"+
 		"External ID:		%s\n"+
 		"Name:			%s\n"+
+		"Display Name:		%s\n"+
 		"State:			%s\n",
 		cluster.ID(),
 		cluster.ExternalID(),
 		cluster.Name(),
+		sub.DisplayName(),
 		cluster.State(),
 	)
 	if cluster.Status().State() == cmv1.ClusterStateError {


### PR DESCRIPTION
Adds the subscription display name (the one used by the web UI) to the describe output