### PR TITLE
OCM-2177 | Add additional status details to the describe cluster output

### DIFF
--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -160,25 +160,35 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 	// Parse Hypershift-related values
 	mgmtClusterName, svcClusterName := findHyperShiftMgmtSvcClusters(connection, cluster)
 
+	provisioningStatus := ""
+	if cluster.Status().State() == cmv1.ClusterStateError && cluster.Status().ProvisionErrorCode() != "" {
+		provisioningStatus = fmt.Sprintf("(%s - %s)",
+			cluster.Status().ProvisionErrorCode(),
+			cluster.Status().ProvisionErrorMessage(),
+		)
+	}
+
 	// Print short cluster description:
 	fmt.Printf("\n"+
 		"ID:			%s\n"+
 		"External ID:		%s\n"+
 		"Name:			%s\n"+
 		"Display Name:		%s\n"+
-		"State:			%s\n",
+		"State:			%s %s\n",
 		cluster.ID(),
 		cluster.ExternalID(),
 		cluster.Name(),
 		sub.DisplayName(),
 		cluster.State(),
+		provisioningStatus,
 	)
-	if cluster.Status().State() == cmv1.ClusterStateError {
-		fmt.Printf("Details:		%s - %s\n",
-			cluster.Status().ProvisionErrorCode(),
-			cluster.Status().ProvisionErrorMessage(),
+
+	if cluster.Status().Description() != "" {
+		fmt.Printf("Details:		%s\n",
+			cluster.Status().Description(),
 		)
 	}
+
 	fmt.Printf("API URL:		%s\n"+
 		"API Listening:		%s\n"+
 		"Console URL:		%s\n"+


### PR DESCRIPTION
This is similar to the change done in [ROSA CLI](https://github.com/openshift/rosa/commit/f3065738663e9dcca26d9031a15f05f722825609) and will help the debugging.

Examples:
Normal output
```
State:			ready
```
Additional error
```
State:			error
Details:		Manifest work deletion is stuck
```
Provisioning error
```
State:			error (OCM3999 - Unknown error. Check this cluster's installation logs for more details, or delete this cluster and try again. If this issue persists, contact support.)
```

Related: OCM-2177