### PR TITLE
improve GetCluster message when Subscription exists but is inactive

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -148,8 +148,7 @@ func GetCluster(connection *sdk.Connection, key string) (cluster *cmv1.Cluster, 
 
 	// Try to find a matching subscription:
 	subsSearch := fmt.Sprintf(
-		"(display_name = '%s' or cluster_id = '%s' or external_cluster_id = '%s') and "+
-			"status in ('Reserved', 'Active')",
+		"(display_name = '%s' or cluster_id = '%s' or external_cluster_id = '%s')",
 		key, key, key,
 	)
 	subsListResponse, err := subsResource.List().
@@ -164,7 +163,14 @@ func GetCluster(connection *sdk.Connection, key string) (cluster *cmv1.Cluster, 
 	// If there is exactly one matching subscription then return the corresponding cluster:
 	subsTotal := subsListResponse.Total()
 	if subsTotal == 1 {
-		id, ok := subsListResponse.Items().Slice()[0].GetClusterID()
+		sub := subsListResponse.Items().Slice()[0]
+		status, ok := sub.GetStatus()
+		subID, _ := sub.GetID()
+		if !ok || (status != "Reserved" && status != "Active") {
+			err = fmt.Errorf("Cluster was %s, see `ocm get subscription %s` for details", status, subID)
+			return
+		}
+		id, ok := sub.GetClusterID()
 		if ok {
 			var clusterGetResponse *cmv1.ClusterGetResponse
 			clusterGetResponse, err = clustersResource.Cluster(id).Get().


### PR DESCRIPTION
First step towards #517.
At least doesn't lie to user and gives hint how to find past data:

#### before
```
> ocm describe cluster 0e68a621-c00e-4bbf-a4bb-9915ae6cc947
Error: Can't retrieve cluster for key '0e68a621-c00e-4bbf-a4bb-9915ae6cc947': There are no subscriptions or clusters with identifier or name '0e68a621-c00e-4bbf-a4bb-9915ae6cc947'
```
#### after
```
> ocm describe cluster 0e68a621-c00e-4bbf-a4bb-9915ae6cc947
Error: Can't retrieve cluster for key '0e68a621-c00e-4bbf-a4bb-9915ae6cc947': Cluster was Deprovisioned, see `ocm get subscription 2S434jffVG4fSgDdK4cbkDTxVNp` for details``
```

This affects ALL commands that use `GetCluster` helper.

:question: Behavior change: when there is 1 active cluster and also 1+ past clusters reusing same display_name, previously the active one was silently used; now will refuse treating them as ambiguous:
```
> ocm get subs -p search="display_name in ('servheredia')" | jq .items[].status | sort | uniq -c
      4 "Deprovisioned"
      1 "Reserved"
> ocm describe cluster servheredia
Error: Can't retrieve cluster for key 'servheredia': There are 5 subscriptions with cluster identifier or name 'servheredia'
```
is that desired?