### PR TITLE
OCM-2942 | fix: adjust help usage for cluster routes attributes

### DIFF
--- a/cmd/ocm/edit/ingress/cmd.go
+++ b/cmd/ocm/edit/ingress/cmd.go
@@ -139,14 +139,14 @@ func init() {
 		&args.clusterRoutesHostname,
 		clusterRoutesHostnameFlag,
 		"",
-		"Cluster Routes Hostname.",
+		"Components route hostname for oauth, console, download.",
 	)
 
 	flags.StringVar(
 		&args.clusterRoutesTlsSecretRef,
 		clusterRoutesTlsSecretRefFlag,
 		"",
-		"Cluster Routes TLS Secret Reference.",
+		"Components route TLS secret reference for oauth, console, download.",
 	)
 }
 


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-2942