### PR TITLE
OCM-2966 : Feat : Added subscription_type parameter to create cluster command

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -409,12 +409,7 @@ func getSubscriptionTypeOptions(connection *sdk.Connection) ([]arguments.Option,
 		option := subscriptionTypeOption(billingModel.ID(), billingModel.Description())
 		//Standard billing model should always be the first option
 		if billingModel.ID() == billing.StandardSubscriptionType {
-			if len(options) == 0 { // nil or empty slice or after last element
-				options = append(options, option)
-			} else {
-				options = append(options[:1], options[0:]...)
-				options[0] = option
-			}
+			options = append([]arguments.Option{option}, options...)
 		} else {
 			options = append(options, option)
 		}

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -19,7 +19,6 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/openshift-online/ocm-cli/pkg/billing"
 	"io"
 	"net"
 	"os"
@@ -29,6 +28,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/openshift-online/ocm-cli/cmd/ocm/edit/ingress"
 	"github.com/openshift-online/ocm-cli/pkg/arguments"
+	"github.com/openshift-online/ocm-cli/pkg/billing"
 	c "github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	"github.com/openshift-online/ocm-cli/pkg/provider"

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -406,9 +406,9 @@ func getSubscriptionTypeOptions(connection *sdk.Connection) ([]arguments.Option,
 		return options, err
 	}
 	for _, billingModel := range billingModels {
-		option := subscriptionTypeOption(billingModel.Id(), billingModel.Description())
+		option := subscriptionTypeOption(billingModel.ID(), billingModel.Description())
 		//Standard billing model should always be the first option
-		if billingModel.Id() == billing.StandardSubscriptionType {
+		if billingModel.ID() == billing.StandardSubscriptionType {
 			if len(options) == 0 { // nil or empty slice or after last element
 				options = append(options, option)
 			} else {
@@ -485,7 +485,7 @@ func preRun(cmd *cobra.Command, argv []string) error {
 	providers, _ := osdProviderOptions(connection)
 	// If marketplace-gcp subscription type is used, provider can only be GCP
 	gcpBillingModel, _ := billing.GetBillingModel(connection, billing.MarketplaceGcpSubscriptionType)
-	gcpSubscriptionTypeTemplate := subscriptionTypeOption(gcpBillingModel.Id(), gcpBillingModel.Description())
+	gcpSubscriptionTypeTemplate := subscriptionTypeOption(gcpBillingModel.ID(), gcpBillingModel.Description())
 	isGcpMarketplaceSubscriptionType := args.subscriptionType == gcpSubscriptionTypeTemplate.Value
 
 	if isGcpMarketplaceSubscriptionType {

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -504,7 +504,7 @@ func preRun(cmd *cobra.Command, argv []string) error {
 		fmt.Println("setting ccs to 'true'")
 		args.ccs.Enabled = true
 	}
-	err = promptCCS(fs, args.ccs.Enabled == true)
+	err = promptCCS(fs, args.ccs.Enabled)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/nwidger/jsoncolor v0.3.2
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
-	github.com/openshift-online/ocm-sdk-go v0.1.367
+	github.com/openshift-online/ocm-sdk-go v0.1.368
 	github.com/openshift/rosa v1.2.24
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/nwidger/jsoncolor v0.3.2
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
-	github.com/openshift-online/ocm-sdk-go v0.1.356
+	github.com/openshift-online/ocm-sdk-go v0.1.367
 	github.com/openshift/rosa v1.2.24
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
-github.com/openshift-online/ocm-sdk-go v0.1.356 h1:FFUAi+mR5pdBsp3pisXp7M4SiFdxKQwNwKTQNY7QDY0=
-github.com/openshift-online/ocm-sdk-go v0.1.356/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
+github.com/openshift-online/ocm-sdk-go v0.1.367 h1:17eJeoorPLhrHRte3vUGPxIKRDS8BEp1Uv+XhHPY87k=
+github.com/openshift-online/ocm-sdk-go v0.1.367/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/rosa v1.2.24 h1:vv0yYnWHx6CCPEAau/0rS54P2ksaf+uWXb1TQPWxiYE=
 github.com/openshift/rosa v1.2.24/go.mod h1:MVXB27O3PF8WoOic23I03mmq6/9kVxpFx6FKyLMCyrQ=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
-github.com/openshift-online/ocm-sdk-go v0.1.367 h1:17eJeoorPLhrHRte3vUGPxIKRDS8BEp1Uv+XhHPY87k=
-github.com/openshift-online/ocm-sdk-go v0.1.367/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
+github.com/openshift-online/ocm-sdk-go v0.1.368 h1:qP+gkChV8WDwwpkUw1xUyjTXKdvrwyd70Gff2GMUSeU=
+github.com/openshift-online/ocm-sdk-go v0.1.368/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/rosa v1.2.24 h1:vv0yYnWHx6CCPEAau/0rS54P2ksaf+uWXb1TQPWxiYE=
 github.com/openshift/rosa v1.2.24/go.mod h1:MVXB27O3PF8WoOic23I03mmq6/9kVxpFx6FKyLMCyrQ=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=

--- a/pkg/billing/billing.go
+++ b/pkg/billing/billing.go
@@ -11,7 +11,11 @@ const (
 	MarketplaceGcpSubscriptionType = "marketplace-gcp"
 )
 
-var ValidSubscriptionTypes = []string{StandardSubscriptionType, MarketplaceRhmSubscriptionType, MarketplaceGcpSubscriptionType}
+var ValidSubscriptionTypes = []string{
+	StandardSubscriptionType,
+	MarketplaceRhmSubscriptionType,
+	MarketplaceGcpSubscriptionType,
+}
 
 func GetBillingModel(connection *sdk.Connection, billingModelID string) (*amv1.BillingModelItem, error) {
 	bilingModel, err := connection.AccountsMgmt().V1().BillingModels().BillingModel(billingModelID).Get().Send()

--- a/pkg/billing/billing.go
+++ b/pkg/billing/billing.go
@@ -1,0 +1,39 @@
+package billing
+
+import (
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+)
+
+const (
+	StandardSubscriptionType       = "standard"
+	MarketplaceRhmSubscriptionType = "marketplace-rhm"
+	MarketplaceGcpSubscriptionType = "marketplace-gcp"
+)
+
+var ValidSubscriptionTypes = []string{StandardSubscriptionType, MarketplaceRhmSubscriptionType, MarketplaceGcpSubscriptionType}
+
+func GetBillingModel(connection *sdk.Connection, billingModelID string) (*amv1.BillingModelItem, error) {
+	bilingModel, err := connection.AccountsMgmt().V1().BillingModels().BillingModel(billingModelID).Get().Send()
+	if err != nil {
+		return nil, err
+	}
+	return bilingModel.Body(), nil
+}
+
+func GetBillingModels(connection *sdk.Connection) ([]*amv1.BillingModelItem, error) {
+	response, err := connection.AccountsMgmt().V1().BillingModels().List().Send()
+	if err != nil {
+		return nil, err
+	}
+	billingModels := response.Items().Slice()
+	var validBillingModel []*amv1.BillingModelItem
+	for _, billingModel := range billingModels {
+		for _, validSubscriptionTypeId := range ValidSubscriptionTypes {
+			if billingModel.Id() == validSubscriptionTypeId {
+				validBillingModel = append(validBillingModel, billingModel)
+			}
+		}
+	}
+	return validBillingModel, nil
+}

--- a/pkg/billing/billing.go
+++ b/pkg/billing/billing.go
@@ -30,7 +30,7 @@ func GetBillingModels(connection *sdk.Connection) ([]*amv1.BillingModelItem, err
 	var validBillingModel []*amv1.BillingModelItem
 	for _, billingModel := range billingModels {
 		for _, validSubscriptionTypeId := range ValidSubscriptionTypes {
-			if billingModel.Id() == validSubscriptionTypeId {
+			if billingModel.ID() == validSubscriptionTypeId {
 				validBillingModel = append(validBillingModel, billingModel)
 			}
 		}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	amsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
@@ -705,7 +705,7 @@ func GetClusterAddOns(connection *sdk.Connection, clusterID string) ([]*AddOnIte
 			}
 
 			// Only display add-ons for which the org has quota
-			quotaCosts.Each(func(quotaCost *amsv1.QuotaCost) bool {
+			quotaCosts.Each(func(quotaCost *amv1.QuotaCost) bool {
 				relatedResources := quotaCost.RelatedResources()
 				for _, relatedResource := range relatedResources {
 					if relatedResource.ResourceType() == "add-on" &&

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -68,6 +68,7 @@ type Spec struct {
 	ChannelGroup     string
 	Expiration       time.Time
 	EtcdEncryption   bool
+	SubscriptionType string
 
 	// Scaling config
 	ComputeMachineType string
@@ -312,6 +313,7 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec, dryRun bool) (*cmv1.Clu
 				ID(config.Flavour),
 		).
 		EtcdEncryption(config.EtcdEncryption).
+		BillingModel(cmv1.BillingModel(config.SubscriptionType)).
 		Properties(clusterProperties)
 
 	clusterBuilder = clusterBuilder.Version(

--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -196,6 +196,7 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 		"Infra:			%d\n"+
 		"Computes:		%s\n"+
 		"Product:		%s\n"+
+		"Subscription type:	%s\n"+
 		"Provider:		%s\n"+
 		"Version:		%s\n"+
 		"Region:			%s\n"+
@@ -221,6 +222,7 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 		cluster.Nodes().Infra(),
 		computesStr,
 		cluster.Product().ID(),
+		cluster.BillingModel(),
 		cluster.CloudProvider().ID(),
 		cluster.OpenshiftVersion(),
 		cluster.Region().ID(),


### PR DESCRIPTION
**Changed**
- Added subscription_type parameter to create cluster command
- Added validation to have one of the specific options for the command
- Defaulted subscription_type to standard

**Tested**
- Cluster should be created based on the subscription_type parameter passed in cli : tested 