### PR TITLE
OCM-3510 | fix: allow clusters to edit ingresses

### DIFF
--- a/cmd/ocm/edit/ingress/cmd.go
+++ b/cmd/ocm/edit/ingress/cmd.go
@@ -191,11 +191,6 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Failed to get cluster '%s': %v", clusterKey, err)
 	}
 
-	if cluster.CloudProvider().ID() != "aws" {
-		return fmt.Errorf(
-			"Editing ingresses is not supported for cloud provider '%s'", cluster.CloudProvider().ID())
-	}
-
 	if cluster.State() != cmv1.ClusterStateReady {
 		return fmt.Errorf("Cluster '%s' is not yet ready", clusterKey)
 	}


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-3510

Best to let backend deal with this decision