### PR TITLE
OCM-3801 | Feat | Added default values for CIDRs and host prefix

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -371,6 +371,34 @@ func getFlavourOptions(connection *sdk.Connection) ([]arguments.Option, error) {
 	return options, nil
 }
 
+func GetDefaultClusterFlavors(connection *sdk.Connection, flavour string) (dMachinecidr *net.IPNet, dPodcidr *net.IPNet,
+	dServicecidr *net.IPNet, dhostPrefix int) {
+	flavourGetResponse, err := connection.ClustersMgmt().V1().Flavours().Flavour(flavour).Get().Send()
+	if err != nil {
+		flavourGetResponse, _ = connection.ClustersMgmt().V1().Flavours().Flavour("osd-4").Get().Send()
+	}
+
+	network, ok := flavourGetResponse.Body().GetNetwork()
+	if !ok {
+		return nil, nil, nil, 0
+	}
+	_, dMachinecidr, err = net.ParseCIDR(network.MachineCIDR())
+	if err != nil {
+		dMachinecidr = nil
+	}
+	_, dPodcidr, err = net.ParseCIDR(network.PodCIDR())
+	if err != nil {
+		dPodcidr = nil
+	}
+	_, dServicecidr, err = net.ParseCIDR(network.ServiceCIDR())
+	if err != nil {
+		dServicecidr = nil
+	}
+	dhostPrefix, _ = network.GetHostPrefix()
+
+	return dMachinecidr, dPodcidr, dServicecidr, dhostPrefix
+}
+
 func getVersionOptions(connection *sdk.Connection) ([]arguments.Option, error) {
 	options, _, err := getVersionOptionsWithDefault(connection, "")
 	return options, err
@@ -593,6 +621,11 @@ func preRun(cmd *cobra.Command, argv []string) error {
 	err = promptClusterWideProxy()
 	if err != nil {
 		return err
+	}
+
+	if args.interactive {
+		machineCIDR, serviceCIDR, podCIDR, hostPrefix := GetDefaultClusterFlavors(connection, args.flavour)
+		args.machineCIDR, args.serviceCIDR, args.podCIDR, args.hostPrefix = *machineCIDR, *serviceCIDR, *podCIDR, hostPrefix
 	}
 
 	err = promptNetwork(fs)

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -624,8 +624,8 @@ func preRun(cmd *cobra.Command, argv []string) error {
 	}
 
 	if args.interactive {
-		machineCIDR, serviceCIDR, podCIDR, hostPrefix := GetDefaultClusterFlavors(connection, args.flavour)
-		args.machineCIDR, args.serviceCIDR, args.podCIDR, args.hostPrefix = *machineCIDR, *serviceCIDR, *podCIDR, hostPrefix
+		machineCIDR, podCIDR, serviceCIDR, hostPrefix := GetDefaultClusterFlavors(connection, args.flavour)
+		args.machineCIDR, args.podCIDR, args.serviceCIDR, args.hostPrefix = *machineCIDR, *podCIDR, *serviceCIDR, hostPrefix
 	}
 
 	err = promptNetwork(fs)

--- a/pkg/arguments/interactive.go
+++ b/pkg/arguments/interactive.go
@@ -302,6 +302,8 @@ func PromptIPNet(fs *pflag.FlagSet, flagName string) error {
 		prompt := &survey.Input{
 			Message: getQuestion(flag),
 			Help:    flag.Usage,
+			// TODO respect flag default, if set
+			// (awkward because https://github.com/golang/go/issues/39516).
 			Default: flag.DefValue,
 		}
 		var response string

--- a/pkg/arguments/interactive.go
+++ b/pkg/arguments/interactive.go
@@ -295,12 +295,14 @@ func PromptIPNet(fs *pflag.FlagSet, flagName string) error {
 		if flag.Changed {
 			return nil
 		}
-
+		// If the default value is nil, set the value as a default value
+		if flag.DefValue == "<nil>" {
+			flag.DefValue = flag.Value.String()
+		}
 		prompt := &survey.Input{
 			Message: getQuestion(flag),
 			Help:    flag.Usage,
-			// TODO respect flag default, if set
-			// (awkward because https://github.com/golang/go/issues/39516).
+			Default: flag.DefValue,
 		}
 		var response string
 		// Set() flag as side effect of validation => prompts again if invalid.

--- a/pkg/arguments/interactive.go
+++ b/pkg/arguments/interactive.go
@@ -295,15 +295,14 @@ func PromptIPNet(fs *pflag.FlagSet, flagName string) error {
 		if flag.Changed {
 			return nil
 		}
-		// If the default value is nil, set the value as a default value
+		// We set the default value here (if nil) so that shown on the console when the user does not provide any input
+		// (awkward because https://github.com/golang/go/issues/39516).
 		if flag.DefValue == "<nil>" {
 			flag.DefValue = flag.Value.String()
 		}
 		prompt := &survey.Input{
 			Message: getQuestion(flag),
 			Help:    flag.Usage,
-			// TODO respect flag default, if set
-			// (awkward because https://github.com/golang/go/issues/39516).
 			Default: flag.DefValue,
 		}
 		var response string


### PR DESCRIPTION
**Changed**
- Fetched default values from flavour endpoint
- Set the values for CIDRs and host prefix

**Tested**
- CIDR and host prefix should have the default values auto populated in case of no other input : tested