### PR TITLE
OCM 3768 | Feat | Filtered OCM versions for marketplace gcp clusters

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -400,16 +401,16 @@ func GetDefaultClusterFlavors(connection *sdk.Connection, flavour string) (dMach
 }
 
 func getVersionOptions(connection *sdk.Connection) ([]arguments.Option, error) {
-	options, _, err := getVersionOptionsWithDefault(connection, "")
+	options, _, err := getVersionOptionsWithDefault(connection, "", nil)
 	return options, err
 }
 
-func getVersionOptionsWithDefault(connection *sdk.Connection, channelGroup string) (
+func getVersionOptionsWithDefault(connection *sdk.Connection, channelGroup string, gcpMarketplaceEnabled *string) (
 	options []arguments.Option, defaultVersion string, err error,
 ) {
 	// Check and set the cluster version
 	versionList, defaultVersion, err := c.GetEnabledVersions(
-		connection.ClustersMgmt().V1(), channelGroup)
+		connection.ClustersMgmt().V1(), channelGroup, gcpMarketplaceEnabled)
 	if err != nil {
 		return
 	}
@@ -551,7 +552,12 @@ func preRun(cmd *cobra.Command, argv []string) error {
 		return err
 	}
 
-	versions, defaultVersion, err := getVersionOptionsWithDefault(connection, args.channelGroup)
+	var gcpMarketplaceEnabled string
+	if isGcpMarketplaceSubscriptionType {
+		gcpMarketplaceEnabled = strconv.FormatBool(isGcpMarketplaceSubscriptionType)
+	}
+	versions, defaultVersion, err := getVersionOptionsWithDefault(connection, args.channelGroup,
+		&gcpMarketplaceEnabled)
 	if err != nil {
 		return err
 	}

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -401,11 +401,11 @@ func GetDefaultClusterFlavors(connection *sdk.Connection, flavour string) (dMach
 }
 
 func getVersionOptions(connection *sdk.Connection) ([]arguments.Option, error) {
-	options, _, err := getVersionOptionsWithDefault(connection, "", nil)
+	options, _, err := getVersionOptionsWithDefault(connection, "", "")
 	return options, err
 }
 
-func getVersionOptionsWithDefault(connection *sdk.Connection, channelGroup string, gcpMarketplaceEnabled *string) (
+func getVersionOptionsWithDefault(connection *sdk.Connection, channelGroup string, gcpMarketplaceEnabled string) (
 	options []arguments.Option, defaultVersion string, err error,
 ) {
 	// Check and set the cluster version
@@ -557,7 +557,7 @@ func preRun(cmd *cobra.Command, argv []string) error {
 		gcpMarketplaceEnabled = strconv.FormatBool(isGcpMarketplaceSubscriptionType)
 	}
 	versions, defaultVersion, err := getVersionOptionsWithDefault(connection, args.channelGroup,
-		&gcpMarketplaceEnabled)
+		gcpMarketplaceEnabled)
 	if err != nil {
 		return err
 	}

--- a/cmd/ocm/list/version/cmd.go
+++ b/cmd/ocm/list/version/cmd.go
@@ -74,7 +74,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	defer connection.Close()
 
 	client := connection.ClustersMgmt().V1()
-	versions, defaultVersion, err := cluster.GetEnabledVersions(client, args.channelGroup, &args.gcpMarketplace)
+	versions, defaultVersion, err := cluster.GetEnabledVersions(client, args.channelGroup, args.gcpMarketplace)
 	if err != nil {
 		return fmt.Errorf("Can't retrieve versions: %v", err)
 	}

--- a/cmd/ocm/list/version/cmd.go
+++ b/cmd/ocm/list/version/cmd.go
@@ -27,6 +27,7 @@ import (
 var args struct {
 	defaultVersion bool
 	channelGroup   string
+	gcpMarketplace string
 }
 
 var Cmd = &cobra.Command{
@@ -55,6 +56,13 @@ func init() {
 		"stable",
 		"List only versions from the specified channel group",
 	)
+
+	fs.StringVar(
+		&args.gcpMarketplace,
+		"gcp-marketplace",
+		"",
+		"List only versions that support 'marketplace-gcp' subscription type",
+	)
 }
 
 func run(cmd *cobra.Command, argv []string) error {
@@ -66,7 +74,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	defer connection.Close()
 
 	client := connection.ClustersMgmt().V1()
-	versions, defaultVersion, err := cluster.GetEnabledVersions(client, args.channelGroup)
+	versions, defaultVersion, err := cluster.GetEnabledVersions(client, args.channelGroup, &args.gcpMarketplace)
 	if err != nil {
 		return fmt.Errorf("Can't retrieve versions: %v", err)
 	}

--- a/cmd/ocm/list/version/cmd.go
+++ b/cmd/ocm/list/version/cmd.go
@@ -27,7 +27,7 @@ import (
 var args struct {
 	defaultVersion bool
 	channelGroup   string
-	gcpMarketplace string
+	marketplaceGcp string
 }
 
 var Cmd = &cobra.Command{
@@ -58,8 +58,8 @@ func init() {
 	)
 
 	fs.StringVar(
-		&args.gcpMarketplace,
-		"gcp-marketplace",
+		&args.marketplaceGcp,
+		"marketplace-gcp",
 		"",
 		"List only versions that support 'marketplace-gcp' subscription type",
 	)
@@ -74,7 +74,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	defer connection.Close()
 
 	client := connection.ClustersMgmt().V1()
-	versions, defaultVersion, err := cluster.GetEnabledVersions(client, args.channelGroup, args.gcpMarketplace)
+	versions, defaultVersion, err := cluster.GetEnabledVersions(client, args.channelGroup, args.marketplaceGcp)
 	if err != nil {
 		return fmt.Errorf("Can't retrieve versions: %v", err)
 	}

--- a/pkg/cluster/versions.go
+++ b/pkg/cluster/versions.go
@@ -42,12 +42,15 @@ func EnsureOpenshiftVPrefix(v string) string {
 // GetEnabledVersions returns the versions with enabled=true, and the one that has default=true.
 // The returned strings are the IDs without "openshift-v" prefix (e.g. "4.6.0-rc.4-candidate")
 // sorted in approximate SemVer order (handling of text parts is somewhat arbitrary).
-func GetEnabledVersions(client *cmv1.Client, channelGroup string) (
+func GetEnabledVersions(client *cmv1.Client, channelGroup string, gcpMarketplaceEnabled *string) (
 	versions []string, defaultVersion string, err error) {
 	collection := client.Versions()
 	page := 1
 	size := 100
 	filter := "enabled = 'true'"
+	if gcpMarketplaceEnabled != nil && *gcpMarketplaceEnabled != "" {
+		filter = fmt.Sprintf("%s AND gcp_marketplace_enabled = '%s'", filter, *gcpMarketplaceEnabled)
+	}
 	if channelGroup != "" {
 		filter = fmt.Sprintf("%s AND channel_group = '%s'", filter, channelGroup)
 	}

--- a/pkg/cluster/versions.go
+++ b/pkg/cluster/versions.go
@@ -42,14 +42,14 @@ func EnsureOpenshiftVPrefix(v string) string {
 // GetEnabledVersions returns the versions with enabled=true, and the one that has default=true.
 // The returned strings are the IDs without "openshift-v" prefix (e.g. "4.6.0-rc.4-candidate")
 // sorted in approximate SemVer order (handling of text parts is somewhat arbitrary).
-func GetEnabledVersions(client *cmv1.Client, channelGroup string, gcpMarketplaceEnabled *string) (
+func GetEnabledVersions(client *cmv1.Client, channelGroup string, gcpMarketplaceEnabled string) (
 	versions []string, defaultVersion string, err error) {
 	collection := client.Versions()
 	page := 1
 	size := 100
 	filter := "enabled = 'true'"
-	if gcpMarketplaceEnabled != nil && *gcpMarketplaceEnabled != "" {
-		filter = fmt.Sprintf("%s AND gcp_marketplace_enabled = '%s'", filter, *gcpMarketplaceEnabled)
+	if gcpMarketplaceEnabled != "" {
+		filter = fmt.Sprintf("%s AND gcp_marketplace_enabled = '%s'", filter, gcpMarketplaceEnabled)
 	}
 	if channelGroup != "" {
 		filter = fmt.Sprintf("%s AND channel_group = '%s'", filter, channelGroup)


### PR DESCRIPTION
**Changed**
- Added gcpMarketplaceEnabled flag for filtering out supported versions of OCM CLI

**Tested**
- Only supported versions should be visible for gcp marketplace clusters : tested