### PR TITLE
Release v0.1.69

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,15 +5,11 @@ This document describes the relevant changes between releases of the
 
 ## 0.1.69 Sep 29 2023
 
--447488d Added default values for CIDRs and host prefix
--672ca8b Fixed CIDR order and added back the comment
--fbff80f Fixed the comment statement
--1f2b39b fix duplicate machine pool information printed for the same cluster
--f0fadd8 add tests for list machinepools command
--5b60bbf added failure tests for list machinepools command
--498c54e Filtered OCM versions for marketplace gcp clusters
--a9f32b7 Changed string pointer to string and removed nil check
--0aca318 Changed gcp-marketplace keyword to marketplace-gcp
+- 447488d Added default values for CIDRs and host prefix
+- 1f2b39b fix duplicate machine pool information printed for the same cluster
+- f0fadd8 add tests for list machinepools command
+- 5b60bbf added failure tests for list machinepools command
+- 498c54e Filtered OCM versions for marketplace gcp clusters
 
 ## 0.1.68 Sep 12 2023
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,18 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+## 0.1.69 Sep 29 2023
+
+-447488d Added default values for CIDRs and host prefix
+-672ca8b Fixed CIDR order and added back the comment
+-fbff80f Fixed the comment statement
+-1f2b39b fix duplicate machine pool information printed for the same cluster
+-f0fadd8 add tests for list machinepools command
+-5b60bbf added failure tests for list machinepools command
+-498c54e Filtered OCM versions for marketplace gcp clusters
+-a9f32b7 Changed string pointer to string and removed nil check
+-0aca318 Changed gcp-marketplace keyword to marketplace-gcp
+
 ## 0.1.68 Sep 12 2023
 
 - Bump k8s.io/apimachinery from 0.27.2 to 0.27.3

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "0.1.68"
+const Version = "0.1.69"


### PR DESCRIPTION
-447488d Added default values for CIDRs and host prefix -672ca8b Fixed CIDR order and added back the comment -fbff80f Fixed the comment statement
-1f2b39b fix duplicate machine pool information printed for the same cluster -f0fadd8 add tests for list machinepools command
-5b60bbf added failure tests for list machinepools command -498c54e Filtered OCM versions for marketplace gcp clusters -a9f32b7 Changed string pointer to string and removed nil check -0aca318 Changed gcp-marketplace keyword to marketplace-gcp