### PR TITLE
OCM-4184 | Feat | Convert relative path containing tilde for service account file

### DIFF
--- a/pkg/arguments/interactive.go
+++ b/pkg/arguments/interactive.go
@@ -301,12 +301,10 @@ func resolveRelativePath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dir := usr.HomeDir
-	absPath := dir
-	if strings.HasPrefix(path, "~/") && len(path) > 2 {
-		absPath = filepath.Join(dir, path[2:])
+	if strings.HasPrefix(path, "~/") {
+		path = strings.Replace(path, "~", usr.HomeDir, 1)
 	}
-	return absPath, nil
+	return path, nil
 }
 
 // PromptIPNet sets an optional IPNet flag value interactively, unless already set.

--- a/pkg/arguments/interactive.go
+++ b/pkg/arguments/interactive.go
@@ -294,6 +294,9 @@ func PromptFilePath(fs *pflag.FlagSet, flagName string, required bool) error {
 // Golang does not support tilde file paths https://github.com/golang/go/issues/57569
 // However, we try to resolve this by manually so user can proceed further
 func resolveRelativePath(path string) (string, error) {
+	if !strings.Contains(path, "~") {
+		return path, nil
+	}
 	usr, err := user.Current()
 	if err != nil {
 		return "", err

--- a/pkg/arguments/interactive.go
+++ b/pkg/arguments/interactive.go
@@ -299,15 +299,11 @@ func resolveRelativePath(path string) (string, error) {
 		return "", err
 	}
 	dir := usr.HomeDir
-	if path == "~" {
-		// In case of "~", "else if" would not catch that
-		path = dir
-	} else if strings.HasPrefix(path, "~/") {
-		// Use strings.HasPrefix so we don't match paths like
-		// "/something/~/something/"
-		path = filepath.Join(dir, path[2:])
+	absPath := dir
+	if strings.HasPrefix(path, "~/") && len(path) > 2 {
+		absPath = filepath.Join(dir, path[2:])
 	}
-	return path, nil
+	return absPath, nil
 }
 
 // PromptIPNet sets an optional IPNet flag value interactively, unless already set.


### PR DESCRIPTION
**Changed**
- Convert relative path containing tilde for service account file

**Tested**
- Path containing tilde should be valid for service account file