### PR TITLE
OCM-4186 | Feat | Changed marketplace-gcp-terms error message for non-interactive mode

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -50,7 +50,8 @@ const (
 		"/marketplace/agreements/redhat-marketplace/red-hat-openshift-dedicated"
 	gcpTermsAgreementInteractiveError    = "Please accept Google Terms and Agreements in order to proceed"
 	gcpTermsAgreementNonInteractiveError = "Review and accept Google Terms and Agreements on " +
-		gcpTermsAgreementsHyperlink + ". Set the flag --marketplace-gcp-terms to true once agreed in order to proceed further."
+		gcpTermsAgreementsHyperlink + ". Set the flag --marketplace-gcp-terms to true " +
+		"once agreed in order to proceed further."
 )
 
 var args struct {

--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -48,7 +48,9 @@ const (
 	defaultIngressNamespaceOwnershipPolicyFlag = "default-ingress-namespace-ownership-policy"
 	gcpTermsAgreementsHyperlink                = "https://console.cloud.google.com" +
 		"/marketplace/agreements/redhat-marketplace/red-hat-openshift-dedicated"
-	gcpTermsAgreementError = "Please accept Google Terms and Agreements in order to proceed"
+	gcpTermsAgreementInteractiveError    = "Please accept Google Terms and Agreements in order to proceed"
+	gcpTermsAgreementNonInteractiveError = "Review and accept Google Terms and Agreements on " +
+		gcpTermsAgreementsHyperlink + ". Set the flag --marketplace-gcp-terms to true once agreed in order to proceed further."
 )
 
 var args struct {
@@ -539,7 +541,10 @@ func preRun(cmd *cobra.Command, argv []string) error {
 			}
 		}
 		if !args.marketplaceGcpTerms {
-			return fmt.Errorf(gcpTermsAgreementError)
+			if args.interactive {
+				return fmt.Errorf(gcpTermsAgreementInteractiveError)
+			}
+			return fmt.Errorf(gcpTermsAgreementNonInteractiveError)
 		}
 	} else {
 		err = arguments.PromptOneOf(fs, "provider", providers)


### PR DESCRIPTION
**Changed**
- Changed marketplace-gcp-terms error message for non-interactive mode

**Tested**
- Non-interactive mode should throw an error `"Error: Review and accept Google Terms and Agreements on https://console.cloud.google.com/marketplace/agreements/redhat-marketplace/red-hat-openshift-dedicated. Set the flag --marketplace-gcp-terms to true once agreed in order to proceed further."` : tested