### PR TITLE
Add vpc-project-id flag for shared VPC on GCP

### DIFF
--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -204,6 +204,14 @@ func AddExistingVPCFlags(fs *pflag.FlagSet, value *cluster.ExistingVPC) {
 	)
 	SetQuestion(fs, "compute-subnet", "compute subnet:")
 
+	fs.StringVar(
+		&value.VPCProjectID,
+		"vpc-project-id",
+		"",
+		"The name of the project the existing VPC is located for shared VPC on GCP",
+	)
+	SetQuestion(fs, "vpc-project-id", "vpc project id:")
+
 	fs.StringSliceVar(
 		&value.AdditionalComputeSecurityGroupIds,
 		additionalComputeSecurityGroupIdsFlag,


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCM-4465

Adds `--vpc-project-id` flag to specify host project id when creating a shared-vpc GCP cluster. 

In the interactive flow, if the user selects yes to `Install into an existing VPC` they will get a follow-up prompt `Install into a shared VPC`, which defaults to No.

```
? Install into an existing VPC (optional): Yes
? vpc name: <vpc-name>
? control plane subnet: <subnet-name>
? compute subnet: <subnet-name>
? Install into a shared VPC (optional): Yes
? Vpc project id: <project-name>
```

In the existing flow when `use-existing-vpc` is true the cli will run client-side validation that the vpc and subnets exist. If using shared vpc this validation will be skipped (because it can't be verified with existing credentials).
