### PR TITLE
OCM-4783 | feat: display warnings after cluster creation

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -750,6 +750,10 @@ func run(cmd *cobra.Command, argv []string) error {
 		if err != nil {
 			return err
 		}
+		err = c.PrintClusterWarnings(connection, cluster)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -25,6 +25,7 @@ import (
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	slv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 )
 
 const (
@@ -344,4 +345,18 @@ func findHyperShiftMgmtSvcClusters(conn *sdk.Connection, cluster *cmv1.Cluster) 
 
 	// Shouldn't normally happen as every management cluster should have a service cluster
 	return mgmtClusterName, ""
+}
+
+func PrintClusterWarnings(connection *sdk.Connection, cluster *cmv1.Cluster) error {
+	serviceLogs, err := connection.ServiceLogs().V1().Clusters().ClusterLogs().List().ClusterID(cluster.ID()).Send()
+	if err != nil {
+		return err
+	}
+	serviceLogs.Items().Each(func(entry *slv1.LogEntry) bool {
+		if entry.Severity() == slv1.SeverityWarning {
+			fmt.Printf("⚠️ WARNING:\n%s\n%s\n", entry.Summary(), entry.Description())
+		}
+		return true
+	})
+	return nil
 }


### PR DESCRIPTION
Demo:
```
[rcampos@rcampos-thinkpadt14sgen2i ocm-cli]$ ./ocm create cluster -i
? cluster name rc-test
? Subscription type: standard (Annual: Fixed capacity subscription from Red Hat)
? Cloud provider: gcp
? CCS: Yes
? Service account file: REDACTED
? Multiple AZ: No
? Secure boot support for Shielded VMs: No
? Region: us-east4
? OpenShift version: 4.14.6
? Compute machine type: custom-4-16384
? Enable autoscaling: No
? Compute nodes: 2
? Install into an existing VPC (optional): No
? Machine CIDR: 10.0.0.0/16
? Service CIDR: 172.30.0.0/16
? Pod CIDR: 10.128.0.0/14
? Host prefix: 23
? Private cluster (optional): No

ID:                     REDACTED
External ID:
Name:                   rc-test
Display Name:           rc-test
State:                  validating
API URL:
API Listening:          external
Console URL:
Control Plane:
        Replicas: 3
Infra:
        Replicas: 2
Compute:
        Replicas: 2
Product:                osd
Subscription type:      standard
Provider:               gcp
Version:
Region:                 us-east4
Multi-az:               false
CCS:                    true
HCP:                    false
Subnet IDs:             []
PrivateLink:            false
STS:                    false
Existing VPC:           unsupported
Channel Group:          stable
Cluster Admin:          true
Organization:           REDACTED
Creator:                REDACTED
Email:                  rcampos@redhat.com
AccountNumber:          REDACTED
Created:                2023-12-20T19:58:20Z
Shard:                  REDACTED

⚠️ WARNING:
Please enable the Org Policy API for the GCP project 'REDACTED'
Without the GCP Org Policy API enabled, OCM is unable to determine whether the GCP project contains any policies that would affect the in
stallation
```