### PR TITLE
OCM-3226 | feat: improving ocm login and ocm list rh-region url resolution

### DIFF
--- a/cmd/ocm/list/rhRegion/cmd.go
+++ b/cmd/ocm/list/rhRegion/cmd.go
@@ -2,11 +2,20 @@ package rhRegion
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
 	sdk "github.com/openshift-online/ocm-sdk-go"
 
 	"github.com/openshift-online/ocm-cli/pkg/config"
+	"github.com/openshift-online/ocm-cli/pkg/urls"
 	"github.com/spf13/cobra"
 )
+
+var args struct {
+	discoveryURL string
+}
 
 var Cmd = &cobra.Command{
 	Use:   "rh-regions",
@@ -18,24 +27,40 @@ ocm list rh-regions`,
 	Hidden: true,
 }
 
+func init() {
+	flags := Cmd.Flags()
+	flags.StringVar(
+		&args.discoveryURL,
+		"discovery-url",
+		"",
+		"URL of the OCM API gateway. If not provided, will reuse the URL from the configuration "+
+			"file or "+sdk.DefaultURL+" as a last resort. The value should be a complete URL "+
+			"or a valid URL alias: "+strings.Join(urls.ValidOCMUrlAliases(), ", "),
+	)
+}
+
 func run(cmd *cobra.Command, argv []string) error {
-	// Load the configuration file:
-	cfg, err := config.Load()
+
+	cfg, _ := config.Load()
+
+	gatewayURL, err := urls.ResolveGatewayURL(args.discoveryURL, cfg)
 	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
-	}
-	if cfg == nil {
-		return fmt.Errorf("Not logged in, run the 'login' command")
+		return err
 	}
 
-	regions, err := sdk.GetRhRegions(cfg.URL)
+	fmt.Fprintf(os.Stdout, "Discovery URL: %s\n\n", gatewayURL)
+	regions, err := sdk.GetRhRegions(gatewayURL)
 	if err != nil {
 		return fmt.Errorf("Failed to get OCM regions: %w", err)
 	}
 
-	for regionName := range regions {
-		fmt.Println(regionName)
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.TabIndent)
+	fmt.Fprintf(writer, "RH Region\t\tGateway URL\n")
+	for regionName, region := range regions {
+		fmt.Fprintf(writer, "%s\t\t%v\n", regionName, region.URL)
 	}
-	return nil
+
+	err = writer.Flush()
+	return err
 
 }

--- a/pkg/urls/main_test.go
+++ b/pkg/urls/main_test.go
@@ -1,0 +1,13 @@
+package urls
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestURLs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "URLs")
+}

--- a/pkg/urls/url_expander_test.go
+++ b/pkg/urls/url_expander_test.go
@@ -17,16 +17,9 @@ limitations under the License.
 package urls
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-func TestURLExpander(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "URL expander")
-}
 
 type urlExpanderTest struct {
 	params      []string

--- a/pkg/urls/well_known.go
+++ b/pkg/urls/well_known.go
@@ -18,5 +18,71 @@ limitations under the License.
 
 package urls
 
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/openshift-online/ocm-cli/pkg/config"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+)
+
 // OfflineTokenPage is the URL of the page used to generate offline access tokens.
 const OfflineTokenPage = "https://console.redhat.com/openshift/token" // #nosec G101
+
+const (
+	OCMProductionURL  = "https://api.openshift.com"
+	OCMStagingURL     = "https://api.stage.openshift.com"
+	OCMIntegrationURL = "https://api.integration.openshift.com"
+)
+
+var OCMURLAliases = map[string]string{
+	"production":  OCMProductionURL,
+	"prod":        OCMProductionURL,
+	"prd":         OCMProductionURL,
+	"staging":     OCMStagingURL,
+	"stage":       OCMStagingURL,
+	"stg":         OCMStagingURL,
+	"integration": OCMIntegrationURL,
+	"int":         OCMIntegrationURL,
+}
+
+func ValidOCMUrlAliases() []string {
+	keys := make([]string, 0, len(OCMURLAliases))
+	for k := range OCMURLAliases {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// URL Precedent (from highest priority to lowest priority):
+//  1. runtime `--url` cli arg (key found in `urlAliases`)
+//  2. runtime `--url` cli arg (non-empty string)
+//  3. config file `URL` value (non-empty string)
+//  4. sdk.DefaultURL
+//
+// Finally, it will try to url.ParseRequestURI the resolved URL to make sure it's a valid URL.
+func ResolveGatewayURL(optionalParsedCliFlagValue string, optionalParsedConfig *config.Config) (string, error) {
+	gatewayURL := sdk.DefaultURL
+	source := "default"
+	if optionalParsedCliFlagValue != "" {
+		gatewayURL = optionalParsedCliFlagValue
+		source = "flag"
+		if _, ok := OCMURLAliases[optionalParsedCliFlagValue]; ok {
+			gatewayURL = OCMURLAliases[optionalParsedCliFlagValue]
+		}
+	} else if optionalParsedConfig != nil && optionalParsedConfig.URL != "" {
+		// re-use the URL from the config file
+		gatewayURL = optionalParsedConfig.URL
+		source = "config"
+	}
+
+	url, err := url.ParseRequestURI(gatewayURL)
+	if err != nil {
+		return "", fmt.Errorf(
+			"%w\n\nURL Source: %s\nExpected an absolute URI/path (e.g. %s) or a case-sensitive alias, one of: [%s]",
+			err, source, sdk.DefaultURL, strings.Join(ValidOCMUrlAliases(), ", "))
+	}
+
+	return url.String(), nil
+}

--- a/pkg/urls/well_known_test.go
+++ b/pkg/urls/well_known_test.go
@@ -1,0 +1,103 @@
+package urls
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift-online/ocm-cli/pkg/config"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+)
+
+var _ = Describe("Gateway URL Resolution", func() {
+
+	var nilConfig *config.Config = nil
+	var emptyConfig *config.Config = &config.Config{}
+	var emptyURLConfig *config.Config = &config.Config{URL: ""}
+	var nonEmptyURLConfig *config.Config = &config.Config{URL: "https://api.example.com"}
+	validUrlOverrides := []string{
+		"https://api.example.com", "http://api.example.com", "http://localhost",
+		"http://localhost:8080", "https://localhost:8080/", "unix://my.server.com/tmp/api.socket",
+		"unix+https://my.server.com/tmp/api.socket", "h2c://api.example.com",
+		"unix+h2c://my.server.com/tmp/api.socket",
+	}
+	invalidUrlOverrides := []string{
+		//nolint:misspell // intentional misspellings
+		"productin", "PRod", //alias typo
+		"localhost", "192.168.1.1", "api.openshift.com", //ip address/hostname without protocol
+	}
+
+	It("Prority 1 - cli arg valid url aliases", func() {
+		for alias, url := range OCMURLAliases {
+			resolved, err := ResolveGatewayURL(alias, nilConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(url))
+
+			resolved, err = ResolveGatewayURL(alias, emptyConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(url))
+
+			resolved, err = ResolveGatewayURL(alias, emptyURLConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(url))
+
+			resolved, err = ResolveGatewayURL(alias, nonEmptyURLConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(url))
+		}
+	})
+
+	It("Priority 2 - cli arg valid url", func() {
+		for _, urlOverride := range validUrlOverrides {
+			resolved, err := ResolveGatewayURL(urlOverride, nilConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(urlOverride))
+
+			resolved, err = ResolveGatewayURL(urlOverride, emptyConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(urlOverride))
+
+			resolved, err = ResolveGatewayURL(urlOverride, emptyURLConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(urlOverride))
+
+			resolved, err = ResolveGatewayURL(urlOverride, nonEmptyURLConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(urlOverride))
+		}
+	})
+
+	It("Priority 3 - valid config url", func() {
+		for _, urlOverride := range validUrlOverrides {
+			resolved, err := ResolveGatewayURL("", &config.Config{URL: urlOverride})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resolved).To(Equal(urlOverride))
+		}
+	})
+
+	It("Priority 4 - api.openshift.com", func() {
+		resolved, err := ResolveGatewayURL("", nilConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(sdk.DefaultURL))
+
+		resolved, err = ResolveGatewayURL("", emptyConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(sdk.DefaultURL))
+
+		resolved, err = ResolveGatewayURL("", emptyURLConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resolved).To(Equal(sdk.DefaultURL))
+	})
+
+	It("Invalid url alias throws an error", func() {
+		for _, urlOverride := range invalidUrlOverrides {
+			_, err := ResolveGatewayURL(urlOverride, nilConfig)
+			Expect(err).To(HaveOccurred())
+		}
+	})
+
+	It("Invalid cfg.URL throws an error", func() {
+		for _, urlOverride := range invalidUrlOverrides {
+			_, err := ResolveGatewayURL("", &config.Config{URL: urlOverride})
+			Expect(err).To(HaveOccurred())
+		}
+	})
+})


### PR DESCRIPTION
This MR tweaks the `ocm login --url` resolution algorithm to try to reuse `cfg.URL` before falling back to "api.openshift.com". New `--url` resolution algorithm (from highest priority to lowest priority):

1. runtime `--url` cli arg (key found in `urlAliases`)
2. runtime `--url` cli arg (non-empty string)
3. [NEW] config file `URL` value (non-empty string)
4. sdk.DefaultURL

I also improved the recently added `ocm list rh-region` to be a bit more helpful:
* show discovery URL used
* add optional `--discovery-url` flag with the same url resolution behavior as `ocm login`
* tabular formatting
* display region name and its associated url rather than just region name