### PR TITLE
OCM-5941 | add enable delete protection parameter

### DIFF
--- a/cmd/ocm/edit/cluster/cmd.go
+++ b/cmd/ocm/edit/cluster/cmd.go
@@ -29,9 +29,9 @@ import (
 
 var args struct {
 	// Basic options
-	expirationTime     string
-	expirationDuration time.Duration
-
+	expirationTime         string
+	expirationDuration     time.Duration
+	enableDeleteProtection bool
 	// Networking options
 	private bool
 
@@ -119,6 +119,12 @@ func init() {
 		"A file contains a PEM-encoded X.509 certificate bundle that will be "+
 			"added to the nodes' trusted certificate store.")
 
+	flags.BoolVar(
+		&args.enableDeleteProtection,
+		"enable-delete-protection",
+		false,
+		"Enable cluster delete protection against accidental cluster deletion.",
+	)
 }
 
 func isGCPNetworkEmpty(network *cmv1.GCPNetwork) bool {
@@ -220,6 +226,15 @@ func run(cmd *cobra.Command, argv []string) error {
 			}
 		}
 		noProxy = args.clusterWideProxy.NoProxy
+	}
+
+	var enableDeleteProtection bool
+	if cmd.Flags().Changed("enable-delete-protection") {
+		enableDeleteProtection = args.enableDeleteProtection
+		err := c.UpdateDeleteProtection(clusterCollection, cluster.ID(), enableDeleteProtection)
+		if err != nil {
+			return err
+		}
 	}
 
 	var additionalTrustBundleFile *string

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -580,12 +580,20 @@ func UpdateCluster(client *cmv1.ClustersClient, clusterID string, config Spec) e
 	if err != nil {
 		return err
 	}
-
 	_, err = client.Cluster(clusterID).Update().Body(clusterSpec).Send()
 	if err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func UpdateDeleteProtection(client *cmv1.ClustersClient, clusterID string, enable bool) error {
+	deleteProtection, _ := cmv1.NewDeleteProtection().Enabled(enable).Build()
+	_, err := client.Cluster(clusterID).DeleteProtection().Update().Body(deleteProtection).Send()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Added --enable-delete-protection argument to the edit option.

## How to test it:
- Login and create a fake cluster called 'mycluster'
- ` go run cmd/ocm/main.go edit cluster mycluster --enable-delete-protection --debug`
```
I0228 13:00:07.139670  356406 dump.go:134] Request method is PATCH
I0228 13:00:07.139677  356406 dump.go:135] Request URL is 'http://localhost:9000/api/clusters_mgmt/v1/clusters/29lqu9n9kif8t7ergv0vfra1eeqd4kgu/delete_protection'
I0228 13:00:07.139683  356406 dump.go:153] Request header 'Accept' is 'application/json'
I0228 13:00:07.139689  356406 dump.go:151] Request header 'Authorization' is omitted
I0228 13:00:07.139694  356406 dump.go:153] Request header 'Content-Type' is 'application/json'
I0228 13:00:07.139699  356406 dump.go:153] Request header 'User-Agent' is 'OCM-CLI/0.1.72'
I0228 13:00:07.139706  356406 dump.go:158] Request body follows
I0228 13:00:07.139715  356406 dump.go:283] {
  "enabled": true
}
I0228 13:00:07.940433  356406 dump.go:165] Response protocol is 'HTTP/1.1'
I0228 13:00:07.940447  356406 dump.go:166] Response status is '200 OK'
I0228 13:00:07.940458  356406 dump.go:178] Response header 'Connection' is 'keep-alive'
I0228 13:00:07.940464  356406 dump.go:178] Response header 'Content-Type' is 'application/json'
I0228 13:00:07.940469  356406 dump.go:178] Response header 'Date' is 'Wed, 28 Feb 2024 12:00:07 GMT'
I0228 13:00:07.940475  356406 dump.go:178] Response header 'Server' is 'nginx/1.25.3'
I0228 13:00:07.940481  356406 dump.go:178] Response header 'Vary' is 'Accept-Encoding'
I0228 13:00:07.940488  356406 dump.go:178] Response header 'X-Operation-Id' is '46a7b87f-ddb2-48e1-9423-28e59a3c4a72'
I0228 13:00:07.940497  356406 dump.go:182] Response body follows
I0228 13:00:07.940516  356406 dump.go:283] {
  "href": "/api/clusters_mgmt/v1/clusters/29lqu9n9kif8t7ergv0vfra1eeqd4kgu/delete_protection",
  "enabled": true
}
```

Note: This current run will try to update the cluster, possible fix in https://github.com/openshift-online/ocm-cli/pull/601

