### PR TITLE
OCM-6140: make name width to be 54 chars to fix truncation issue in case of longer name > 28 chars

### DIFF
--- a/pkg/output/table_test.go
+++ b/pkg/output/table_test.go
@@ -261,8 +261,8 @@ var _ = Describe("Table", func() {
 		// Check the generated text:
 		lines := strings.Split(buffer.String(), "\n")
 		Expect(lines).To(HaveLen(3))
-		Expect(lines[0]).To(Equal(`ID                                NAME                        `))
-		Expect(lines[1]).To(Equal(`123                               mycluster                   `))
+		Expect(lines[0]).To(Equal(`ID                                NAME                                                  `))
+		Expect(lines[1]).To(Equal(`123                               mycluster                                             `))
 	})
 
 	It("Honours learning limit", func() {

--- a/pkg/output/tables/clusters.yaml
+++ b/pkg/output/tables/clusters.yaml
@@ -20,7 +20,7 @@ columns:
   width: 32
 - name: name
   header: NAME
-  width: 28
+  width: 54
 - name: api.url
   header: API URL
   width: 58


### PR DESCRIPTION
This follows up on https://github.com/openshift-online/ocm-cli/pull/605