### PR TITLE
Adds ability to change api url via env var

### DIFF
--- a/cmd/ocm/account/quota/cmd.go
+++ b/cmd/ocm/account/quota/cmd.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
@@ -60,28 +60,11 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
-	}
-	if cfg == nil {
-		return fmt.Errorf("Not logged in, run the 'login' command")
-	}
 
-	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, reason, err := cfg.Armed()
+	// Create the client for the OCM API:
+	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return err
-	}
-	if !armed {
-		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
-	}
-
-	// Create the connection, and remember to close it:
-	connection, err := cfg.Connection()
-	if err != nil {
-		return fmt.Errorf("Can't create connection: %v", err)
 	}
 	defer connection.Close()
 

--- a/cmd/ocm/account/roles/cmd.go
+++ b/cmd/ocm/account/roles/cmd.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
@@ -57,28 +57,10 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) error {
 
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
-	}
-	if cfg == nil {
-		return fmt.Errorf("Not logged in, run the 'login' command")
-	}
-
-	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, reason, err := cfg.Armed()
+	// Create the client for the OCM API:
+	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return err
-	}
-	if !armed {
-		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
-	}
-
-	// Create the connection, and remember to close it:
-	connection, err := cfg.Connection()
-	if err != nil {
-		return fmt.Errorf("Can't create connection: %v", err)
 	}
 	defer connection.Close()
 

--- a/cmd/ocm/account/status/cmd.go
+++ b/cmd/ocm/account/status/cmd.go
@@ -18,11 +18,13 @@ package status
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	acc_util "github.com/openshift-online/ocm-cli/pkg/account"
 	"github.com/openshift-online/ocm-cli/pkg/config"
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
@@ -61,19 +63,10 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Not logged in, run the 'login' command")
 	}
 
-	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, reason, err := cfg.Armed()
+	// Create the client for the OCM API:
+	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return err
-	}
-	if !armed {
-		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
-	}
-
-	// Create the connection, and remember to close it:
-	connection, err := cfg.Connection()
-	if err != nil {
-		return fmt.Errorf("Can't create connection: %v", err)
 	}
 	defer connection.Close()
 
@@ -87,8 +80,12 @@ func run(cmd *cobra.Command, argv []string) error {
 	// Display user and which server they are logged into
 	currAccount := response.Body()
 	currOrg := currAccount.Organization()
-	fmt.Printf("User %s on %s in org '%s' %s (external_id: %s)",
+	fmt.Printf("User %s on %s in org '%s' %s (external_id: %s) ",
 		currAccount.Username(), cfg.URL, currOrg.Name(), currOrg.ID(), currOrg.ExternalID())
+
+	if urlOverride := os.Getenv("OCM_URL"); urlOverride != "" {
+		fmt.Printf("- OCM_URL overridden via env to %s - ", urlOverride)
+	}
 
 	// Display roles currently assigned to the user
 	roleSlice, err := acc_util.GetRolesFromUsers([]*amv1.Account{currAccount}, connection)

--- a/cmd/ocm/account/status/cmd.go
+++ b/cmd/ocm/account/status/cmd.go
@@ -18,7 +18,6 @@ package status
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -82,10 +81,6 @@ func run(cmd *cobra.Command, argv []string) error {
 	currOrg := currAccount.Organization()
 	fmt.Printf("User %s on %s in org '%s' %s (external_id: %s) ",
 		currAccount.Username(), cfg.URL, currOrg.Name(), currOrg.ID(), currOrg.ExternalID())
-
-	if urlOverride := os.Getenv("OCM_URL"); urlOverride != "" {
-		fmt.Printf("- OCM_URL overridden via env to %s - ", urlOverride)
-	}
 
 	// Display roles currently assigned to the user
 	roleSlice, err := acc_util.GetRolesFromUsers([]*amv1.Account{currAccount}, connection)

--- a/cmd/ocm/account/users/cmd.go
+++ b/cmd/ocm/account/users/cmd.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	acc_util "github.com/openshift-online/ocm-cli/pkg/account"
-	"github.com/openshift-online/ocm-cli/pkg/config"
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 )
 
@@ -74,28 +74,10 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) error {
 
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
-	}
-	if cfg == nil {
-		return fmt.Errorf("Not logged in, run the 'login' command")
-	}
-
-	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, reason, err := cfg.Armed()
+	// Create the client for the OCM API:
+	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return err
-	}
-	if !armed {
-		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
-	}
-
-	// Create the connection, and remember to close it:
-	connection, err := cfg.Connection()
-	if err != nil {
-		return fmt.Errorf("Can't create connection: %v", err)
 	}
 	defer connection.Close()
 

--- a/cmd/ocm/get/cmd.go
+++ b/cmd/ocm/get/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
@@ -69,20 +70,12 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Not logged in, run the 'login' command")
 	}
 
-	// Check that the configuration has credentials or tokens that don't have expired:
-	armed, reason, err := cfg.Armed()
+	// Create the client for the OCM API:
+	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return err
 	}
-	if !armed {
-		return fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
-	}
-
-	// Create the connection:
-	connection, err := cfg.Connection()
-	if err != nil {
-		return fmt.Errorf("Can't create connection: %v", err)
-	}
+	defer connection.Close()
 
 	// Create and populate the request:
 	request := connection.Get()

--- a/cmd/ocm/login/cmd.go
+++ b/cmd/ocm/login/cmd.go
@@ -315,7 +315,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	if overrideUrl := os.Getenv(properties.URLEnvKey); overrideUrl != "" {
-		fmt.Fprintf(os.Stderr, "WARNING: the `%s` environment variable is set, but is not used for the login command. The `ocm login` command will only use the explicitly set flag's url, which is set as %s\n", properties.URLEnvKey, gatewayURL)
+		fmt.Fprintf(os.Stderr, "WARNING: the `%s` environment variable is set, but is not used for the login command. The `ocm login` command will only use the explicitly set flag's url, which is set as %s\n", properties.URLEnvKey, gatewayURL) //nolint:lll
 	}
 
 	// Update the configuration with the values given in the command line:

--- a/cmd/ocm/login/cmd.go
+++ b/cmd/ocm/login/cmd.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/openshift-online/ocm-cli/pkg/config"
+	"github.com/openshift-online/ocm-cli/pkg/properties"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/openshift-online/ocm-sdk-go/authentication"
@@ -313,8 +314,8 @@ func run(cmd *cobra.Command, argv []string) error {
 		gatewayURL = fmt.Sprintf("https://%s", regValue.URL)
 	}
 
-	if overrideUrl := os.Getenv("OCM_URL"); overrideUrl != "" {
-		fmt.Fprintf(os.Stderr, "WARNING: the `OCM_URL` environment variable is set, but is not used for the login command. The `ocm login` command will only use the explicitly set flag's url, which is set as %s\n", gatewayURL)
+	if overrideUrl := os.Getenv(properties.URLEnvKey); overrideUrl != "" {
+		fmt.Fprintf(os.Stderr, "WARNING: the `%s` environment variable is set, but is not used for the login command. The `ocm login` command will only use the explicitly set flag's url, which is set as %s\n", properties.URLEnvKey, gatewayURL)
 	}
 
 	// Update the configuration with the values given in the command line:

--- a/cmd/ocm/login/cmd.go
+++ b/cmd/ocm/login/cmd.go
@@ -313,6 +313,10 @@ func run(cmd *cobra.Command, argv []string) error {
 		gatewayURL = fmt.Sprintf("https://%s", regValue.URL)
 	}
 
+	if overrideUrl := os.Getenv("OCM_URL"); overrideUrl != "" {
+		fmt.Fprintf(os.Stderr, "WARNING: the `OCM_URL` environment variable is set, but is not used for the login command. The `ocm login` command will only use the explicitly set flag's url, which is set as %s\n", gatewayURL)
+	}
+
 	// Update the configuration with the values given in the command line:
 	cfg.TokenURL = tokenURL
 	cfg.ClientID = clientID

--- a/pkg/ocm/connection.go
+++ b/pkg/ocm/connection.go
@@ -15,6 +15,7 @@ package ocm
 
 import (
 	"fmt"
+	"os"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 
@@ -61,6 +62,11 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 	if !armed {
 		err = fmt.Errorf("Not logged in, %s, run the 'login' command", reason)
 		return
+	}
+
+	// overwrite the config URL if the environment variable is set
+	if overrideUrl := os.Getenv("OCM_URL"); overrideUrl != "" {
+		b.cfg.URL = overrideUrl
 	}
 
 	result, err = b.cfg.Connection()

--- a/pkg/ocm/connection.go
+++ b/pkg/ocm/connection.go
@@ -20,6 +20,7 @@ import (
 	sdk "github.com/openshift-online/ocm-sdk-go"
 
 	"github.com/openshift-online/ocm-cli/pkg/config"
+	"github.com/openshift-online/ocm-cli/pkg/debug"
 )
 
 // ConnectionBuilder contains the information and logic needed to build a connection to OCM. Don't
@@ -66,6 +67,11 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 
 	// overwrite the config URL if the environment variable is set
 	if overrideUrl := os.Getenv("OCM_URL"); overrideUrl != "" {
+		if debug.Enabled() {
+			fmt.Fprintln(os.Stderr, "INFO: OCM_URL is overridden via environment variable. This functionality is considered tech preview and may cause unexpected issues.")
+			fmt.Fprintln(os.Stderr, "      If you experience issues while OCM_URL is set, unset the OCM_URL environment variable and attempt to log in directly to the desired OCM environment.")
+			fmt.Fprintln(os.Stderr, "") // add a newline on purpose to separate from ocm sdk debug output
+		}
 		b.cfg.URL = overrideUrl
 	}
 

--- a/pkg/ocm/connection.go
+++ b/pkg/ocm/connection.go
@@ -69,8 +69,8 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 	// overwrite the config URL if the environment variable is set
 	if overrideUrl := os.Getenv(properties.URLEnvKey); overrideUrl != "" {
 		if debug.Enabled() {
-			fmt.Fprintf(os.Stderr, "INFO: %s is overridden via environment variable. This functionality is considered tech preview and may cause unexpected issues.\n", properties.URLEnvKey)
-			fmt.Fprintf(os.Stderr, "      If you experience issues while %s is set, unset the %s environment variable and attempt to log in directly to the desired OCM environment.\n\n", properties.URLEnvKey, properties.URLEnvKey)
+			fmt.Fprintf(os.Stderr, "INFO: %s is overridden via environment variable. This functionality is considered tech preview and may cause unexpected issues.\n", properties.URLEnvKey)                                          //nolint:lll
+			fmt.Fprintf(os.Stderr, "      If you experience issues while %s is set, unset the %s environment variable and attempt to log in directly to the desired OCM environment.\n\n", properties.URLEnvKey, properties.URLEnvKey) //nolint:lll
 		}
 		b.cfg.URL = overrideUrl
 	}

--- a/pkg/ocm/connection.go
+++ b/pkg/ocm/connection.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/debug"
+	"github.com/openshift-online/ocm-cli/pkg/properties"
 )
 
 // ConnectionBuilder contains the information and logic needed to build a connection to OCM. Don't
@@ -66,11 +67,10 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 	}
 
 	// overwrite the config URL if the environment variable is set
-	if overrideUrl := os.Getenv("OCM_URL"); overrideUrl != "" {
+	if overrideUrl := os.Getenv(properties.URLEnvKey); overrideUrl != "" {
 		if debug.Enabled() {
-			fmt.Fprintln(os.Stderr, "INFO: OCM_URL is overridden via environment variable. This functionality is considered tech preview and may cause unexpected issues.")
-			fmt.Fprintln(os.Stderr, "      If you experience issues while OCM_URL is set, unset the OCM_URL environment variable and attempt to log in directly to the desired OCM environment.")
-			fmt.Fprintln(os.Stderr, "") // add a newline on purpose to separate from ocm sdk debug output
+			fmt.Fprintf(os.Stderr, "INFO: %s is overridden via environment variable. This functionality is considered tech preview and may cause unexpected issues.\n", properties.URLEnvKey)
+			fmt.Fprintf(os.Stderr, "      If you experience issues while %s is set, unset the %s environment variable and attempt to log in directly to the desired OCM environment.\n\n", properties.URLEnvKey, properties.URLEnvKey)
 		}
 		b.cfg.URL = overrideUrl
 	}

--- a/pkg/properties/properties.go
+++ b/pkg/properties/properties.go
@@ -16,4 +16,7 @@ limitations under the License.
 
 package properties
 
-const KeyringEnvKey = "OCM_KEYRING"
+const (
+	KeyringEnvKey = "OCM_KEYRING"
+	URLEnvKey     = "OCM_URL"
+)


### PR DESCRIPTION
Adds the ability to change the OCM API URL based on the environment variable `OCM_URL` allowing a user to change the OCM context without changing global state on their machine.

Satisfies OCM-8459.

# Testing

To test this, I built the binary locally and ran a few commands, expecting different output.

* ./ocm list clusters --parameter search="name like 'hs-mc%'"
* OCM_URL=https://api.[regional-api].openshift.com ./ocm list clusters