### PR TITLE
Add wif config cluster create option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/nwidger/jsoncolor v0.3.2
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
-	github.com/openshift-online/ocm-sdk-go v0.1.422
+	github.com/openshift-online/ocm-sdk-go v0.1.433
 	github.com/openshift/rosa v1.2.24
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -361,8 +361,8 @@ github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
-github.com/openshift-online/ocm-sdk-go v0.1.422 h1:NWXLNTg7sLgUJRM3tyuk/QuVbUCRuMH+aLlbCKNzXWc=
-github.com/openshift-online/ocm-sdk-go v0.1.422/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
+github.com/openshift-online/ocm-sdk-go v0.1.433 h1:8i0Si9KrFkMprMBGR1a4ppmgVezMBjjXXkvhv28OVUk=
+github.com/openshift-online/ocm-sdk-go v0.1.433/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/openshift/rosa v1.2.24 h1:vv0yYnWHx6CCPEAau/0rS54P2ksaf+uWXb1TQPWxiYE=
 github.com/openshift/rosa v1.2.24/go.mod h1:MVXB27O3PF8WoOic23I03mmq6/9kVxpFx6FKyLMCyrQ=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=

--- a/pkg/provider/wif_configs.go
+++ b/pkg/provider/wif_configs.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+func getWifConfigs(client *cmv1.Client) (wifConfigs []*cmv1.WifConfig, err error) {
+	collection := client.GCP().WifConfigs()
+	page := 1
+	size := 100
+	for {
+		var response *cmv1.WifConfigsListResponse
+		response, err = collection.List().
+			Page(page).
+			Size(size).
+			Send()
+		if err != nil {
+			return
+		}
+		wifConfigs = append(wifConfigs, response.Items().Slice()...)
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+
+	if len(wifConfigs) == 0 {
+		return nil, fmt.Errorf("no WIF configurations available")
+	}
+	return
+}
+
+func GetWifConfigs(client *cmv1.Client) (wifConfigs []*cmv1.WifConfig, err error) {
+	return getWifConfigs(client)
+}
+
+// GetWifConfigNameOptions returns the wif config options for the cluster
+// with display name as the value and id as the description
+func GetWifConfigNameOptions(client *cmv1.Client) (options []arguments.Option, err error) {
+	wifConfigs, err := getWifConfigs(client)
+	if err != nil {
+		err = fmt.Errorf("failed to retrieve WIF configurations: %s", err)
+		return
+	}
+
+	for _, wc := range wifConfigs {
+		options = append(options, arguments.Option{
+			Value:       wc.DisplayName(),
+			Description: wc.ID(),
+		})
+	}
+	return
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCM-8008

- Adds --wif-config flag for cluster create
- Adds interactive prompt following CCS for authentication method

**Interactive view (select auth type):**
```
? CCS: Yes
? Method of authenticating GCP cluster
? Authentication method:  [Use arrows to move, type to filter]
> Workload Identity Federation (WIF)
  Service account
```

**Interactive view (select WIF config to use):**
```
? CCS: Yes
? Authentication method: Workload Identity Federation (WIF)
? Specifies the GCP Workload Identity Federation config used to authenticate.
? WIF Configuration:  [Use arrows to move, type to filter]
> jdg01 (2crdj6l18l0uqfoqq4873a4alp0t9v4r)
```

**Create cluster help view:**
```
Usage:
  ocm create cluster [flags] NAME

Flags:
      --wif-config string                                     Specifies the GCP Workload Identity Federation config used to authenticate.
```

