### PR TITLE
OCM-10207 | Filter wif configs in interactive mode

### DIFF
--- a/pkg/provider/wif_configs.go
+++ b/pkg/provider/wif_configs.go
@@ -7,7 +7,9 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
-func getWifConfigs(client *cmv1.Client) (wifConfigs []*cmv1.WifConfig, err error) {
+const unusedWifsQuery = "cluster.id is null"
+
+func getWifConfigs(client *cmv1.Client, filter string) (wifConfigs []*cmv1.WifConfig, err error) {
 	collection := client.GCP().WifConfigs()
 	page := 1
 	size := 100
@@ -16,6 +18,7 @@ func getWifConfigs(client *cmv1.Client) (wifConfigs []*cmv1.WifConfig, err error
 		response, err = collection.List().
 			Page(page).
 			Size(size).
+			Search(filter).
 			Send()
 		if err != nil {
 			return
@@ -34,13 +37,38 @@ func getWifConfigs(client *cmv1.Client) (wifConfigs []*cmv1.WifConfig, err error
 }
 
 func GetWifConfigs(client *cmv1.Client) (wifConfigs []*cmv1.WifConfig, err error) {
-	return getWifConfigs(client)
+	return getWifConfigs(client, "")
+}
+
+// GetUnusedWifConfigs returns the WIF configurations that are not associated with any cluster
+func GetUnusedWifConfigs(client *cmv1.Client) (wifConfigs []*cmv1.WifConfig, err error) {
+	return getWifConfigs(client, unusedWifsQuery)
+}
+
+// GetWifConfig returns the WIF configuration where the key is the wif config id or name
+func GetWifConfig(client *cmv1.Client, key string) (wifConfig *cmv1.WifConfig, err error) {
+	query := fmt.Sprintf(
+		"id = '%s' or display_name = '%s'",
+		key, key,
+	)
+	wifs, err := getWifConfigs(client, query)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(wifs) == 0 {
+		return nil, fmt.Errorf("WIF configuration with identifier or name '%s' not found", key)
+	}
+	if len(wifs) > 1 {
+		return nil, fmt.Errorf("there are %d WIF configurations found with identifier or name '%s'", len(wifs), key)
+	}
+	return wifs[0], nil
 }
 
 // GetWifConfigNameOptions returns the wif config options for the cluster
 // with display name as the value and id as the description
 func GetWifConfigNameOptions(client *cmv1.Client) (options []arguments.Option, err error) {
-	wifConfigs, err := getWifConfigs(client)
+	wifConfigs, err := GetUnusedWifConfigs(client)
 	if err != nil {
 		err = fmt.Errorf("failed to retrieve WIF configurations: %s", err)
 		return


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/OCM-10207

Only display options for wif configs that are not used by any existing clusters.

Also accept wif config ID or name when assigning value to `--wif-config` flag