### PR TITLE
Dry-run wif config delete before tearing down cloud resources

### DIFF
--- a/cmd/ocm/gcp/delete-wif-config.go
+++ b/cmd/ocm/gcp/delete-wif-config.go
@@ -70,6 +70,13 @@ func deleteWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 		return errors.Wrapf(err, "failed to get wif-config")
 	}
 
+	// Check if wif-config can be deleted with dry-run
+	_, err = connection.ClustersMgmt().V1().GCP().WifConfigs().
+		WifConfig(wifConfig.ID()).Delete().DryRun(true).Send()
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete wif config %q", wifConfig.ID())
+	}
+
 	if DeleteWifConfigOpts.DryRun {
 		log.Printf("Writing script files to %s", DeleteWifConfigOpts.TargetDir)
 

--- a/cmd/ocm/gcp/list-wif-config.go
+++ b/cmd/ocm/gcp/list-wif-config.go
@@ -30,7 +30,7 @@ func NewListWorkloadIdentityConfiguration() *cobra.Command {
 	fs.StringVar(
 		&ListWorkloadIdentityConfigurationOpts.columns,
 		"columns",
-		"id, display_name",
+		"id, display_name, gcp.project_id",
 		"Specify which columns to display separated by commas, path is based on wif-config struct",
 	)
 	fs.BoolVar(

--- a/pkg/output/tables/wifconfigs.yaml
+++ b/pkg/output/tables/wifconfigs.yaml
@@ -3,3 +3,5 @@ columns:
   header: ID
 - name: displayName
   header: NAME
+- name: gcp.project_id
+  header: PROJECT ID


### PR DESCRIPTION
Issue: [OCM-11561](https://issues.redhat.com/browse/OCM-11561)

Dry-run the delete to verify the wif-config can be deleted so the WIF resources aren't destroyed while in use. 