### PR TITLE
Replace wif dry-run flag with mode

### DIFF
--- a/cmd/ocm/gcp/gcp.go
+++ b/cmd/ocm/gcp/gcp.go
@@ -12,7 +12,7 @@ type options struct {
 	RolePrefix               string
 	WorkloadIdentityPool     string
 	WorkloadIdentityProvider string
-	DryRun                   bool
+	Mode                     string
 }
 
 // NewGcpCmd implements the "gcp" subcommand for the credentials provisioning

--- a/cmd/ocm/gcp/helpers.go
+++ b/cmd/ocm/gcp/helpers.go
@@ -9,6 +9,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	ModeAuto   = "auto"
+	ModeManual = "manual"
+)
+
+var Modes = []string{ModeAuto, ModeManual}
+
 // Checks for WIF config name or id in input
 func wifKeyArgCheck(args []string) error {
 	if len(args) != 1 || args[0] == "" {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCM-11690

`--mode` flag replaces `--dry-run` where:

&nbsp;&nbsp;&nbsp;&nbsp;`mode=auto` is the default and runs all the necessary actions
&nbsp;&nbsp;&nbsp;&nbsp;`mode=manual` can be set and outputs commands to a script to be run manuallly

```
Create workload identity configuration

Usage:
  ocm gcp create wif-config [flags]

Flags:
  -h, --help                 help for wif-config
  -m, --mode string          How to perform the operation. Valid options are:
                             auto (default): Resource changes will be automatic applied using the current GCP account
                             manual: Commands necessary to modify GCP resources will be output to be run manually (default "auto")
      --name string          User-defined name for all created Google cloud resources
      --output-dir string    Directory to place generated files (defaults to current directory)
      --project string       ID of the Google cloud project
      --role-prefix string   Prefix for naming custom roles
```