### PR TITLE
adding interactive mode for WifConfig creation

### DIFF
--- a/cmd/ocm/gcp/gcp.go
+++ b/cmd/ocm/gcp/gcp.go
@@ -5,14 +5,15 @@ import (
 )
 
 type options struct {
-	TargetDir                string
-	Region                   string
+	Interactive              bool
+	Mode                     string
 	Name                     string
 	Project                  string
+	Region                   string
 	RolePrefix               string
+	TargetDir                string
 	WorkloadIdentityPool     string
 	WorkloadIdentityProvider string
-	Mode                     string
 }
 
 // NewGcpCmd implements the "gcp" subcommand for the credentials provisioning


### PR DESCRIPTION
Tests:
```
[rcampos@rcampos-thinkpadt14sgen2i ocm-cli]$ ./ocm gcp create wif-config 
Error: flag 'name' is required
[rcampos@rcampos-thinkpadt14sgen2i ocm-cli]$ ./ocm gcp create wif-config --name rc-test
Error: Flag 'project' is required
[rcampos@rcampos-thinkpadt14sgen2i ocm-cli]$ ./ocm gcp create wif-config --name rc-test --project sda-ccs-1
2024/10/15 16:43:51 Creating workload identity configuration...
```

```
[rcampos@rcampos-thinkpadt14sgen2i ocm-cli]$ ./ocm gcp create wif-config --interactive
? WifConfig name rc-test
? Gcp Project ID sda-ccs-1
2024/10/15 16:44:15 Creating workload identity configuration...
```