### PR TITLE
OCM-11993 | Describe cluster shows WifConfig data

### DIFF
--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -248,7 +248,10 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 			fmt.Printf("Control-Plane-Subnet:   %s\n", cluster.GCPNetwork().ControlPlaneSubnet())
 		}
 		if cluster.GCPNetwork().ComputeSubnet() != "" {
-			fmt.Printf("Compute-Subnet:	        %s\n", cluster.GCPNetwork().ComputeSubnet())
+			fmt.Printf("Compute-Subnet:         %s\n", cluster.GCPNetwork().ComputeSubnet())
+		}
+		if cluster.GCP().Authentication().Id() != "" {
+			fmt.Printf("Wif-Config-Id:          %s\n", cluster.GCP().Authentication().Id())
 		}
 	}
 


### PR DESCRIPTION
```
[rcampos@rcampos-thinkpadt14sgen2i ocm-cli]$ ./ocm describe cluster <REDACTED>

ID:                     <REDACTED>
External ID:            <REDACTED>
Name:                   <REDACTED>
Domain Prefix:          <REDACTED>
Display Name:           <REDACTED>
State:                  ready 
API URL:                <REDACTED>
API Listening:          internal
Console URL:            <REDACTED>
Cluster History URL:    <REDACTED>
Control Plane:
                        Replicas: 3
Infra:
                        Replicas: 3
Compute:
                        Replicas: 3-6 (Autoscaled)
Product:                osd
Subscription type:      standard
Provider:               gcp
Version:                4.17.1
Region:                 us-east1
Multi-az:               true
CNI Type:               OVNKubernetes
SecureBoot:             true
VPC-Name:               osd-ngfw-test-vpc
Control-Plane-Subnet:   osd-ngfw-test-control-plane
Compute-Subnet:         osd-ngfw-test-worker
Wif-Config-Id:          2eilqulr9g8de0k0e2hspk86g2tn3mpr
CCS:                    true
HCP:                    false
Existing VPC:           true
Channel Group:          candidate
Cluster Admin:          true
Organization:           <REDACTED>
Creator:                <REDACTED>
Email:                  <REDACTED>
AccountNumber:          <REDACTED>
Created:                2024-10-22T13:43:03Z
Expiration:             2024-10-24T01:42:58Z
Shard:                  <REDACTED>
```