### PR TITLE
Add more descriptions to WIF resources

### DIFF
--- a/cmd/ocm/gcp/create-wif-config.go
+++ b/cmd/ocm/gcp/create-wif-config.go
@@ -28,8 +28,10 @@ var (
 )
 
 const (
-	poolDescription = "Created by the OLM CLI"
-	roleDescription = "Created by the OLM CLI"
+	// Description for wif-config-specific WIF resources
+	wifDescription = "Created by the OCM CLI for WIF config %s"
+	// Description for OpenShift version-specific WIF IAM roles
+	wifRoleDescription = "Created by the OCM CLI for Workload Identity Federation on OpenShift"
 )
 
 // NewCreateWorkloadIdentityConfiguration provides the "gcp create wif-config" subcommand


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCM-10448

Descriptions are set on the following resources while applying WIF
- Workload Identity Pool
- Workload Identity Pool provider
- Service Accounts
- Custom IAM Roles

For wif-config resources the description is
> Created by the OCM CLI for WIF config {displayName}

For roles, which aren't specific to a wif-config, it is
> Created by the OCM CLI for Workload Identity Federation on OpenShift