### PR TITLE
Add command 'gcp verify wif-config'

### DIFF
--- a/cmd/ocm/gcp/gcp.go
+++ b/cmd/ocm/gcp/gcp.go
@@ -31,6 +31,7 @@ func NewGcpCmd() *cobra.Command {
 	gcpCmd.AddCommand(NewGetCmd())
 	gcpCmd.AddCommand(NewListCmd())
 	gcpCmd.AddCommand(NewDescribeCmd())
+	gcpCmd.AddCommand(NewVerifyCmd())
 
 	return gcpCmd
 }
@@ -115,4 +116,16 @@ func NewDescribeCmd() *cobra.Command {
 	}
 	describeCmd.AddCommand(NewDescribeWorkloadIdentityConfiguration())
 	return describeCmd
+}
+
+// NewVerifyCmd implements the "verify" subcommand
+func NewVerifyCmd() *cobra.Command {
+	verifyCmd := &cobra.Command{
+		Use:   "verify COMMAND",
+		Short: "Verify resources related to GCP.",
+		Long:  "Verify resources related to GCP.",
+		Args:  cobra.MinimumNArgs(1),
+	}
+	verifyCmd.AddCommand(NewVerifyWorkloadIdentityConfiguration())
+	return verifyCmd
 }

--- a/cmd/ocm/gcp/verify-wif-config.go
+++ b/cmd/ocm/gcp/verify-wif-config.go
@@ -1,0 +1,56 @@
+package gcp
+
+import (
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// NewVerifyWorkloadIdentityConfiguration provides the "gcp verify wif-config" subcommand
+func NewVerifyWorkloadIdentityConfiguration() *cobra.Command {
+	verifyWorkloadIdentityCmd := &cobra.Command{
+		Use:   "wif-config [ID|Name]",
+		Short: "Verify a workload identity federation configuration (wif-config) object.",
+		RunE:  verifyWorkloadIdentityConfigurationCmd,
+	}
+
+	return verifyWorkloadIdentityCmd
+}
+
+func verifyWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) error {
+	key, err := wifKeyFromArgs(argv)
+	if err != nil {
+		return err
+	}
+
+	// Create the client for the OCM API:
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create OCM connection")
+	}
+	defer connection.Close()
+
+	// Verify the WIF configuration exists
+	wif, err := findWifConfig(connection.ClustersMgmt().V1(), key)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get wif-config")
+	}
+
+	// Verify the WIF configuration is valid
+	response, err := connection.ClustersMgmt().V1().GCP().WifConfigs().WifConfig(wif.ID()).Status().Get().Send()
+	if err != nil {
+		return errors.Wrapf(err, "failed to verify wif-config")
+	}
+	if !response.Body().Configured() {
+		err := errors.New(response.Body().Description())
+		helpMsg := fmt.Sprintf("Running 'ocm gcp update wif-config' may fix errors related to " +
+			"cloud resource misconfiguration.")
+		return fmt.Errorf("verification failed with error: %v\n%s", err, helpMsg)
+	} else {
+		cmd.Println("WIF configuration is valid")
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/nwidger/jsoncolor v0.3.2
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
-	github.com/openshift-online/ocm-sdk-go v0.1.447
+	github.com/openshift-online/ocm-sdk-go v0.1.449
 	github.com/openshift/rosa v1.2.24
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -361,8 +361,8 @@ github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
-github.com/openshift-online/ocm-sdk-go v0.1.447 h1:PLau6NVgTpwL+L5OcKrBZm+HbET34tjHbENd2GsFhRw=
-github.com/openshift-online/ocm-sdk-go v0.1.447/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
+github.com/openshift-online/ocm-sdk-go v0.1.449 h1:hgegxZuVl8bvR8uA4hCj0/GTfyNLHeQTzBlWXACQX7k=
+github.com/openshift-online/ocm-sdk-go v0.1.449/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/openshift/rosa v1.2.24 h1:vv0yYnWHx6CCPEAau/0rS54P2ksaf+uWXb1TQPWxiYE=
 github.com/openshift/rosa v1.2.24/go.mod h1:MVXB27O3PF8WoOic23I03mmq6/9kVxpFx6FKyLMCyrQ=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OCM-12286

```bash
➜  ocm gcp verify wif-config -h
Verify a workload identity federation configuration (wif-config) object.

Usage:
  ocm gcp verify wif-config [ID|Name] [flags]

Flags:
  -h, --help   help for wif-config

➜  ocm gcp list wif-configs                                                           
ID                                DISPLAY NAME  PROJECT ID
2fdn79v1eg7btv5qlakanc4sq8917ut6  jdg           sda-ccs-1 

# Verify wif-config - passes
➜  ocm gcp verify wif-config jdg
WIF configuration is valid

# Modified wif-config (role removed from service account jdg-gcp-pd-csi-driver-op-7ut6) - fails
➜  ocm gcp verify wif-config jdg
Error: verification failed with error: missing role 'compute.storageAdmin'
Running 'ocm gcp update wif-config' may fix errors related to cloud resource misconfiguration.
exit status 1

# Self repair
➜  ocm gcp update wif-config jdg

# Verify again - passes
➜  ocm gcp verify wif-config jdg
WIF configuration is valid

```