### PR TITLE
OCM-12971 | 'ocm gcp update wif-config' remediates all wif-config misconfigurations

### DIFF
--- a/pkg/gcp/error_handlers.go
+++ b/pkg/gcp/error_handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/gax-go/v2/apierror"
+	googleapi "google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 )
 
@@ -33,4 +34,13 @@ func (c *gcpClient) handleDeleteServiceAccountError(err error, allowMissing bool
 		return nil
 	}
 	return fmt.Errorf(pApiError.Details().String())
+}
+
+// Extracts the text from google api errors for simpler processing
+func (c *gcpClient) fmtGoogleApiError(err error) error {
+	gError, ok := err.(*googleapi.Error)
+	if !ok {
+		return fmt.Errorf("Unexpected error")
+	}
+	return fmt.Errorf(gError.Error())
 }

--- a/pkg/gcp/helpers.go
+++ b/pkg/gcp/helpers.go
@@ -4,6 +4,6 @@ import (
 	"fmt"
 )
 
-func (c *gcpClient) fmtSaResourceId(accountId, projectId string) string {
+func FmtSaResourceId(accountId, projectId string) string {
 	return fmt.Sprintf("projects/%s/serviceAccounts/%s@%s.iam.gserviceaccount.com", projectId, accountId, projectId)
 }


### PR DESCRIPTION
**Overview**
The following new behavior was added to the functionality of the command used to update resources associated with wif-configs:
- re-enable disabled service accounts
- re-enable disabled custom roles
- re-enable disabled workload identity pool
- overwrite identity provider misconfigurations

**Testing**
The resources of a test wif-config resource was manually modified into the states described above. Running `ocm gcp verify wif-config` confirmed that the error related to the misconfiguration was detected. After running `ocm gcp update wif-config`, verification succeeds. Manual inspection of GCP resources confirms that their configuration was corrected through calling the update command.