### PR TITLE
OCM-12391 | feat: Add 'version' flag to wif-config create and update commands

### DIFF
--- a/cmd/ocm/gcp/flag_descriptions.go
+++ b/cmd/ocm/gcp/flag_descriptions.go
@@ -9,4 +9,5 @@ manual:         Commands necessary to modify GCP resources will be output
 `
 
 	targetDirFlagDescription = `Directory to place generated files (defaults to current directory)`
+	versionFlagDescription   = `Version of OpenShift to configure the WIF resources for`
 )

--- a/cmd/ocm/gcp/gcp.go
+++ b/cmd/ocm/gcp/gcp.go
@@ -8,6 +8,7 @@ type options struct {
 	Interactive              bool
 	Mode                     string
 	Name                     string
+	OpenshiftVersion         string
 	Project                  string
 	Region                   string
 	RolePrefix               string

--- a/cmd/ocm/gcp/helpers.go
+++ b/cmd/ocm/gcp/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/pkg/errors"
@@ -81,4 +82,16 @@ func getPathFromFlag(targetDir string) (string, error) {
 	}
 
 	return targetDir, nil
+}
+
+// converts openshift version of form X.Y to template ID of form vX.Y
+func versionToTemplateID(version string) string {
+	// Check if version is a semver in the form X.Y
+	re := regexp.MustCompile(`^\d+\.\d+$`)
+	if re.MatchString(version) {
+		return "v" + version
+	}
+
+	// Otherwise, return the version as is
+	return version
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/nwidger/jsoncolor v0.3.2
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
-	github.com/openshift-online/ocm-sdk-go v0.1.449
+	github.com/openshift-online/ocm-sdk-go v0.1.451
 	github.com/openshift/rosa v1.2.24
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -361,8 +361,8 @@ github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
-github.com/openshift-online/ocm-sdk-go v0.1.449 h1:hgegxZuVl8bvR8uA4hCj0/GTfyNLHeQTzBlWXACQX7k=
-github.com/openshift-online/ocm-sdk-go v0.1.449/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
+github.com/openshift-online/ocm-sdk-go v0.1.451 h1:lkMUmReNb7fOLZagnCp5Hu4yY7UyJH47nPEKSUEUVFw=
+github.com/openshift-online/ocm-sdk-go v0.1.451/go.mod h1:CiAu2jwl3ITKOxkeV0Qnhzv4gs35AmpIzVABQLtcI2Y=
 github.com/openshift/rosa v1.2.24 h1:vv0yYnWHx6CCPEAau/0rS54P2ksaf+uWXb1TQPWxiYE=
 github.com/openshift/rosa v1.2.24/go.mod h1:MVXB27O3PF8WoOic23I03mmq6/9kVxpFx6FKyLMCyrQ=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=


### PR DESCRIPTION
Version flag expects a string representing an Openshift minor release in the form 'X.Y'. On create this sets the wif template used by the wif config. On upgrade, the version is added to the list of templates.

Given a version like `4.17`, the CLI will parse that it is in `X.Y` form and convert it to the expected wif template id form `v4.17`. Otherwise it will pass the input directly for the backend to validate.

Example use:
```
➜  ocm-cli git:(OCM-12391) ✗ go run ./cmd/ocm gcp create wif-config --name=jdg3 --project=sda-ccs-1 --version=4.17 --mode=manual
```

The flag can also be set during interactive create mode:
```
➜  ocm-cli git:(OCM-12391) ✗ go run ./cmd/ocm gcp create wif-config --mode=manual -i
? wif-config name: name
? Gcp Project ID: sda-ccs-1
? The OCP version to configure the wif-config for. Will default to the latest supported version if left unset.
? Openshift version: 
```

**Manual Mode**
Script generated by manually running an update with two versions: [apply.txt](https://github.com/user-attachments/files/18187687/apply.txt)
This doubles the number of roles to create and update

**Tests run**
- Returning 400 when giving an invalid version input
- Update adds new roles for version, and old roles from existing version if missing
- Update generates script covering both versions assigned
- Verify command passes following an update

**Issues:** 
[OCM-12391](https://issues.redhat.com/browse/OCM-12391)
[OCM-12396](https://issues.redhat.com/browse/OCM-12396)