### PR TITLE
OCM-14358 | unbind service accounts when deleting wif-configs

### DIFF
--- a/cmd/ocm/gcp/gcp_client_shim_test.go
+++ b/cmd/ocm/gcp/gcp_client_shim_test.go
@@ -1,0 +1,126 @@
+package gcp
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+)
+
+var _ = Describe("GcpClientShim helper unit tests", func() {
+	Describe("removeMemberFromBinding", func() {
+		const (
+			testMember = "b"
+		)
+		var (
+			testSubject *shim
+			testBinding *cloudresourcemanager.Binding
+		)
+		BeforeEach(func() {
+			testSubject = &shim{}
+			testBinding = &cloudresourcemanager.Binding{
+				Members: []string{"a", testMember, "c"},
+			}
+		})
+		It("does not modify the member list of the binding parameter when member is absent", func() {
+			beforeLen := len(testBinding.Members)
+			modified := testSubject.removeMemberFromBinding(testMember, testBinding)
+			Expect(modified).To(BeTrue(), "the method should report the modification")
+			Expect(len(testBinding.Members)).To(Equal(beforeLen-1),
+				"there should be one less item in the list")
+			for _, member := range testBinding.Members {
+				if member == testMember {
+					Fail(fmt.Sprintf("removed member should no longer be present in list: %v", testBinding.Members))
+				}
+			}
+		})
+		It("modifies the member list of the passed binding when member is present", func() {
+			beforeLen := len(testBinding.Members)
+			modified := testSubject.removeMemberFromBinding("foobar", testBinding)
+			Expect(modified).To(BeFalse(), "the method should report that no modification occurred")
+			Expect(len(testBinding.Members)).To(Equal(beforeLen),
+				"there should be the same number of items in the list")
+		})
+	})
+	Describe("applyMemberToRoleInPolicy", func() {
+		const (
+			testMember = "b"
+			testRole   = "testRole"
+		)
+		var (
+			testSubject    *shim
+			testMembers    []string
+			funcCalled     bool
+			funcParameters struct {
+				member  string
+				binding *cloudresourcemanager.Binding
+			}
+		)
+		BeforeEach(func() {
+			testSubject = &shim{}
+			testMembers = []string{"a", testMember, "c"}
+			funcCalled = false
+		})
+		It("calls the apply function if the role and member is present", func() {
+			modified := testSubject.applyMemberToRoleInPolicy(&cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role:    testRole,
+						Members: testMembers,
+					},
+				},
+			}, testRole, testMember, func(member string, binding *cloudresourcemanager.Binding) bool {
+				funcCalled = true
+				funcParameters.binding = binding
+				funcParameters.member = member
+				return true
+			})
+			Expect(modified).To(BeTrue(), "call should have returned what the apply function returned.")
+			Expect(funcCalled).To(BeTrue(), "apply function should have been called")
+			Expect(funcParameters.binding.Role).To(Equal(testRole),
+				"apply function should have been called with the expected binding")
+			Expect(funcParameters.member).To(Equal(testMember),
+				"apply function should have been called with the expected binding")
+		})
+		It("does not call the apply function if the role is not present", func() {
+			modified := testSubject.applyMemberToRoleInPolicy(&cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role:    "foobar",
+						Members: testMembers,
+					},
+				},
+			}, testRole, testMember, func(member string, binding *cloudresourcemanager.Binding) bool {
+				funcCalled = true
+				funcParameters.binding = binding
+				funcParameters.member = member
+				return true
+			})
+			Expect(funcCalled).To(BeFalse(), "apply function should not have been called")
+			Expect(modified).To(BeFalse(), "no modification should have occurred")
+		})
+		It("does not call the apply function if the member is not present in the role", func() {
+			modified := testSubject.applyMemberToRoleInPolicy(&cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role:    testRole,
+						Members: []string{},
+					},
+				},
+			}, testRole, testMember, func(member string, binding *cloudresourcemanager.Binding) bool {
+				funcCalled = true
+				funcParameters.binding = binding
+				funcParameters.member = member
+				for _, presentMember := range binding.Members {
+					if presentMember == member {
+						return true
+					}
+				}
+				return false
+			})
+			Expect(funcCalled).To(BeTrue(), "the apply function would have been called")
+			Expect(modified).To(BeFalse(), "no modification should have occurred")
+		})
+	})
+})

--- a/cmd/ocm/gcp/gcp_suite_test.go
+++ b/cmd/ocm/gcp/gcp_suite_test.go
@@ -1,0 +1,13 @@
+package gcp_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGcp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gcp Suite")
+}


### PR DESCRIPTION
Deleted service accounts retain their project iam policy bindings. Without unbinding the service accounts that associated with wif-configs, users run the risk of hitting the GCP quota of 1,500 bindings and needing to manually delete these stale policy entries. Through the changes in this commit, service account bindings related to the wif-config being deleted will be unbound.

These changes were confirmed through a combination of unit tests and manual integration tests. The unit tests demonstrate that the logic to remove members from a binding works as expected. 

The correctness of the patch was tested as follows. The count of deleted service account bindings was first tallied. Then a wif-config resource was created. The wif-config resource was then deleted, and a new count of the number of deleted service account bindings was collected. Through this experiment we can see that the count of deleted service accounts does not change. Running the same test with the old cli results in the number of deleted service account bindings going up when the wif-config is deleted.

The attached text file has the log showing the test and the call used to count the  current number of service accounts.

[OCM-14358-test.txt](https://github.com/user-attachments/files/19238800/OCM-14358-test.txt)
