### PR TITLE
OCM-14357 | Ensuring wif commands are resilient to GCP's consistency model

### DIFF
--- a/cmd/ocm/gcp/create-wif-config.go
+++ b/cmd/ocm/gcp/create-wif-config.go
@@ -35,8 +35,6 @@ const (
 	wifDescription = "Created by the OCM CLI for WIF config %s"
 	// Description for OpenShift version-specific WIF IAM roles
 	wifRoleDescription = "Created by the OCM CLI for Workload Identity Federation on OpenShift"
-
-	VerificationTimeoutSeconds = 600
 )
 
 // NewCreateWorkloadIdentityConfiguration provides the "gcp create wif-config" subcommand
@@ -245,7 +243,7 @@ func createWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 			return true, err
 		}
 		return false, nil
-	}, VerificationTimeoutSeconds, log); err != nil {
+	}, IamApiRetrySeconds, log); err != nil {
 		return fmt.Errorf("Timed out verifying wif-config resources\n"+
 			"Please run 'ocm gcp update wif-config %s' to repair potential misconfigurations "+
 			"and to complete the wif-config creation process", wifConfig.ID())

--- a/cmd/ocm/gcp/update-wif-config.go
+++ b/cmd/ocm/gcp/update-wif-config.go
@@ -170,7 +170,7 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 			return true, err
 		}
 		return false, nil
-	}, VerificationTimeoutSeconds, log); err != nil {
+	}, IamApiRetrySeconds, log); err != nil {
 		return fmt.Errorf("Timed out verifying wif-config resources\n"+
 			"Please try 'ocm gcp update wif-config %s' again in a few minutes, "+
 			"or contact Red Hat support.", wifConfig.ID())

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -97,18 +97,6 @@ func HasDuplicates(valSlice []string) (string, bool) {
 	return "", false
 }
 
-func DelayedRetry(f func() error, maxRetries int, delay time.Duration) error {
-	var err error
-	for i := 0; i < maxRetries; i++ {
-		err = f()
-		if err == nil {
-			return nil
-		}
-		time.Sleep(delay)
-	}
-	return fmt.Errorf("Reached max retries. Last error: %s", err.Error())
-}
-
 // Tries the passed in function multiple times within a timeout window,
 // sleeping with backoff in between calls.
 // When non-nil logger is passed as a parameter, log messages about the retry


### PR DESCRIPTION
Because of the iam api's eventual consistency model, wif-config creation may face sporadic permission errors which disrupt the creation process. The below logs show an example of the errors which may occur as part of this issue:
```
-> ocm gcp create wif-config --name dummy-test-march4 --project sda-ccs-1
2025/03/04 10:19:24 Bound roles to principal 'group:sd-sre-platform-gcp-access@redhat.com'
2025/03/04 10:19:24 Workload identity pool created with name '2hafc91hielatppu8oftg5bgle64efts'
2025/03/04 10:19:25 Workload identity provider created with name 'oidc' for pool '2hafc91hielatppu8oftg5bgle64efts'
2025/03/04 10:19:26 IAM service account 'cloud-network-config-ctrl-efts' has been created
2025/03/04 10:19:27 Bound roles to principal 'serviceAccount:cloud-network-config-ctrl-efts@sda-ccs-1.iam.gserviceaccount.com'
2025/03/04 10:19:28 Failed to create IAM service accounts: Failed to attach federated access on service account 'cloud-network-config-ctrl-efts': error details: name = ErrorInfo reason = IAM_PERMISSION_DENIED domain = iam.googleapis.com metadata = map[permission:iam.serviceAccounts.setIamPolicy]
Error: To clean up, run the following command: ocm gcp delete wif-config 2hafc91hielatppu8oftg5bgle64efts 
```

This pull request adds retry with exponential backoff to all iam calls. Instead of terminating the command on call failure, the call is tried again after a sleep period:
```
2025/03/24 16:50:32 Ensuring role bindings for service account 'image-registry-gcs-5lgt'...
2025/03/24 16:50:34 Trying again in 1 seconds...
2025/03/24 16:50:35 Ensuring role bindings for service account 'image-registry-gcs-5lgt'...
2025/03/24 16:50:37 Trying again in 2 seconds...
2025/03/24 16:50:39 Ensuring role bindings for service account 'image-registry-gcs-5lgt'...
```

The attached log shows the user experience for creating, verifying, updating, and deleting wif-configs given these changes.
[OCM-14357-test.txt](https://github.com/user-attachments/files/19455193/OCM-14357-test.txt)
