### PR TITLE
OCM-15741 | remove marketplace-rhm option from subscription-type options

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -706,7 +706,7 @@ func preRun(cmd *cobra.Command, argv []string) error {
 
 	// Get options for subscription type
 	subscriptionTypeOptions, _ := getSubscriptionTypeOptions(connection)
-	err = arguments.PromptOneOf(fs, "subscription-type", subscriptionTypeOptions)
+	err = arguments.PromptOrCheckOneOf(fs, "subscription-type", subscriptionTypeOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/billing/billing.go
+++ b/pkg/billing/billing.go
@@ -7,13 +7,11 @@ import (
 
 const (
 	StandardSubscriptionType       = "standard"
-	MarketplaceRhmSubscriptionType = "marketplace-rhm"
 	MarketplaceGcpSubscriptionType = "marketplace-gcp"
 )
 
 var ValidSubscriptionTypes = []string{
 	StandardSubscriptionType,
-	MarketplaceRhmSubscriptionType,
 	MarketplaceGcpSubscriptionType,
 }
 


### PR DESCRIPTION
From `ocm create cluster --help` menu:
` --subscription-type string  The subscription billing model for the cluster. Options are { standard, marketplace-gcp }. (default "standard")`

From interactive `-i`:
```
? Subscription type:  [Use arrows to move, type to filter, ? for more help]
> standard (Annual: Fixed capacity subscription from Red Hat)
  marketplace-gcp (On-Demand: Flexible usage billed through the Google Cloud Marketplace)
```
  
From flag `--subscription-type`:
```
Error: A valid --subscription-type must be specified.
Valid options: [standard (Annual: Fixed capacity subscription from Red Hat) marketplace-gcp (On-Demand: Flexible usage billed through the Google Cloud Marketplace)]
```