### PR TITLE
OCM-15127 | Add make binary in ocm-cli image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,3 +18,4 @@ LABEL name="ocm"
 COPY LICENSE.txt /licenses
 COPY --from=builder /opt/app-root/src/releases /releases
 COPY --from=builder /opt/app-root/src/releases /usr/local/bin
+COPY --from=builder /usr/bin/make /usr/local/bin


### PR DESCRIPTION
```
yingzhan@yingzhan-mac  ~/ying-work/code/ocm-cli   ying-test ±  podman build -f docker/Dockerfile --platform linux/amd64   -t myocm .
[1/2] STEP 1/4: FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
[1/2] STEP 2/4: COPY . .
--> 157f776b7a99
[1/2] STEP 3/4: ENV GOFLAGS=-buildvcs=false
--> b88a4766c33d
[1/2] STEP 4/4: RUN git config --global --add safe.directory /opt/app-root/src &&     make build_release_images
bash ./hack/build_release_images.sh
go: downloading github.com/golang/glog v1.2.4
go: downloading github.com/spf13/cobra v1.7.0
go: downloading github.com/spf13/pflag v1.0.6
go: downloading cloud.google.com/go/iam v1.1.8
go: downloading github.com/AlecAivazis/survey/v2 v2.3.7
go: downloading github.com/googleapis/gax-go/v2 v2.14.1
go: downloading github.com/openshift-online/ocm-sdk-go v0.1.463
go: downloading github.com/pkg/errors v0.9.1
go: downloading cloud.google.com/go v0.112.2
go: downloading google.golang.org/api v0.211.0
go: downloading google.golang.org/grpc v1.67.1
go: downloading github.com/golang-jwt/jwt/v4 v4.5.2
go: downloading golang.org/x/text v0.21.0
go: downloading k8s.io/apimachinery v0.27.3
go: downloading github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
go: downloading github.com/openshift/rosa v1.2.24
go: downloading github.com/m1/go-generate-password v0.2.0
go: downloading go.uber.org/mock v0.5.0
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/nwidger/jsoncolor v0.3.2
go: downloading gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a
go: downloading cloud.google.com/go/storage v1.39.1
go: downloading github.com/MicahParks/jwkset v0.5.20
go: downloading golang.org/x/term v0.27.0
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576
go: downloading google.golang.org/protobuf v1.35.2
go: downloading google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda
go: downloading github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
go: downloading google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576
go: downloading github.com/json-iterator/go v1.1.12
go: downloading github.com/prometheus/client_golang v1.13.0
go: downloading github.com/cenkalti/backoff/v4 v4.1.3
go: downloading github.com/google/uuid v1.6.0
go: downloading github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
go: downloading golang.org/x/oauth2 v0.24.0
go: downloading github.com/99designs/keyring v1.2.2
go: downloading github.com/zalando/go-keyring v0.2.3
go: downloading github.com/hashicorp/go-version v1.7.0
go: downloading github.com/briandowns/spinner v1.19.0
go: downloading github.com/robfig/cron/v3 v3.0.1
go: downloading github.com/fatih/color v1.13.0
go: downloading golang.org/x/time v0.8.0
go: downloading cloud.google.com/go/compute/metadata v0.5.2
go: downloading golang.org/x/sys v0.28.0
go: downloading github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
go: downloading golang.org/x/net v0.33.0
go: downloading github.com/microcosm-cc/bluemonday v1.0.23
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading github.com/modern-go/reflect2 v1.0.2
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash/v2 v2.3.0
go: downloading github.com/golang/protobuf v1.5.4
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/prometheus/common v0.37.0
go: downloading github.com/prometheus/procfs v0.8.0
go: downloading github.com/dvsekhvalnov/jose2go v1.6.0
go: downloading github.com/mtibben/percent v0.2.1
go: downloading github.com/alessio/shellescape v1.4.1
go: downloading github.com/aws/aws-sdk-go v1.44.110
go: downloading github.com/sirupsen/logrus v1.9.0
go: downloading github.com/zgalor/weberr v0.7.0
go: downloading github.com/ghodss/yaml v1.0.0
go: downloading github.com/mattn/go-isatty v0.0.16
go: downloading github.com/mattn/go-colorable v0.1.13
go: downloading cloud.google.com/go/auth v0.12.1
go: downloading cloud.google.com/go/auth/oauth2adapt v0.2.6
go: downloading go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0
go: downloading go.opencensus.io v0.24.0
go: downloading go.opentelemetry.io/otel v1.29.0
go: downloading go.opentelemetry.io/otel/trace v1.29.0
go: downloading go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0
go: downloading github.com/aymerick/douceur v0.2.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.2
go: downloading github.com/google/s2a-go v0.1.8
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading go.opentelemetry.io/otel/metric v1.29.0
go: downloading github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
go: downloading github.com/googleapis/enterprise-certificate-proxy v0.3.4
go: downloading github.com/go-logr/logr v1.4.2
go: downloading github.com/jmespath/go-jmespath v0.4.0
go: downloading github.com/felixge/httpsnoop v1.0.4
go: downloading github.com/gorilla/css v1.0.0
go: downloading github.com/go-logr/stdr v1.2.2
go: downloading golang.org/x/sync v0.10.0
go: downloading golang.org/x/crypto v0.31.0
  adding: ocm (deflated 58%)
go: downloading github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c
go: downloading github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2
go: downloading github.com/godbus/dbus/v5 v5.1.0
  adding: ocm (deflated 58%)
go: downloading github.com/inconshreveable/mousetrap v1.1.0
go: downloading github.com/danieljoos/wincred v1.2.0
  adding: ocm.exe (deflated 58%)
--> edd54164c8ab
[2/2] STEP 1/12: FROM registry.access.redhat.com/ubi9/ubi-micro:latest
[2/2] STEP 2/12: LABEL description="A CLI tool for working with OCM API"
--> Using cache 223cd617d72a192ab5c45e47c8f445f7ab9cec452f1d559045066aea7cbeb38d
--> 223cd617d72a
[2/2] STEP 3/12: LABEL io.k8s.description="A CLI tool for working with OCM API"
--> Using cache 717aa3f6cbd9546e287ff5827376bd43d8d298c460c3da6129816fe3259bef53
--> 717aa3f6cbd9
[2/2] STEP 4/12: LABEL io.k8s.display-name="OCM CLI"
--> Using cache e83816ef6fab10dd559d8f39e3f8778cb7814adf78193d9c9704819be8ba9aed
--> e83816ef6fab
[2/2] STEP 5/12: LABEL io.openshift.tags="ocm"
--> Using cache e164a22ae65aae999632b63b8f09417c3afadb57050c841229d27c82a04f2843
--> e164a22ae65a
[2/2] STEP 6/12: LABEL summary="Provides the ocm CLI binary"
--> Using cache b572a4d0c4f52df3135b063d9318cd15ac1080d1ad9fbb605609f30490eb55ea
--> b572a4d0c4f5
[2/2] STEP 7/12: LABEL com.redhat.component="ocm"
--> Using cache 250847f91ac690f982e0510a351335821e7a37d4a7fa316d3be29a81bedbdd0c
--> 250847f91ac6
[2/2] STEP 8/12: LABEL name="ocm"
--> Using cache 301b6945bdabb9b036ee01e361061613cd2452337444f1ba007aa2068e7fbc94
--> 301b6945bdab
[2/2] STEP 9/12: COPY LICENSE.txt /licenses
--> Using cache b2e3cb6b0d7c9e58af15d02742f3605cffa59453b2e6fb53207097d793aa5029
--> b2e3cb6b0d7c
[2/2] STEP 10/12: COPY --from=builder /opt/app-root/src/releases /releases
--> 6d8c6ecaae10
[2/2] STEP 11/12: COPY --from=builder /opt/app-root/src/releases /usr/local/bin
--> 7fc48ba09222
[2/2] STEP 12/12: COPY --from=builder /usr/bin/make /usr/local/bin
[2/2] COMMIT myocm
--> 24dac77bd133
Successfully tagged localhost/myocm:latest
24dac77bd13384e3fc8558fd41993e32484e531deeeef1e5d54f322f37bb2f03
 yingzhan@yingzhan-mac  ~/ying-work/code/ocm-cli   ying-test ±  podman run -it 24dac77bd13384e3fc8558fd41993e32484e531deeeef1e5d54f322f37bb2f03 /bin/bash
bash-5.1# make
make: *** No targets specified and no makefile found.  Stop.
bash-5.1# make -h
Usage: make [options] [target] ...
Options:
  -b, -m                      Ignored for compatibility.
  -B, --always-make           Unconditionally make all targets.
  -C DIRECTORY, --directory=DIRECTORY
                              Change to DIRECTORY before doing anything.
  -d                          Print lots of debugging information.
  --debug[=FLAGS]             Print various types of debugging information.
  -e, --environment-overrides
                              Environment variables override makefiles.
  -E STRING, --eval=STRING    Evaluate STRING as a makefile statement.
  -f FILE, --file=FILE, --makefile=FILE
                              Read FILE as a makefile.
  -h, --help                  Print this message and exit.
  -i, --ignore-errors         Ignore errors from recipes.
  -I DIRECTORY, --include-dir=DIRECTORY
                              Search DIRECTORY for included makefiles.
  -j [N], --jobs[=N]          Allow N jobs at once; infinite jobs with no arg.
  -k, --keep-going            Keep going when some targets can't be made.
  -l [N], --load-average[=N], --max-load[=N]
                              Don't start multiple jobs unless load is below N.
  -L, --check-symlink-times   Use the latest mtime between symlinks and target.
  -n, --just-print, --dry-run, --recon
                              Don't actually run any recipe; just print them.
  -o FILE, --old-file=FILE, --assume-old=FILE
                              Consider FILE to be very old and don't remake it.
  -O[TYPE], --output-sync[=TYPE]
                              Synchronize output of parallel jobs by TYPE.
  -p, --print-data-base       Print make's internal database.
  -q, --question              Run no recipe; exit status says if up to date.
  -r, --no-builtin-rules      Disable the built-in implicit rules.
  -R, --no-builtin-variables  Disable the built-in variable settings.
  -s, --silent, --quiet       Don't echo recipes.
  --no-silent                 Echo recipes (disable --silent mode).
  -S, --no-keep-going, --stop
                              Turns off -k.
  -t, --touch                 Touch targets instead of remaking them.
  --trace                     Print tracing information.
  -v, --version               Print the version number of make and exit.
  -w, --print-directory       Print the current directory.
  --no-print-directory        Turn off -w, even if it was turned on implicitly.
  -W FILE, --what-if=FILE, --new-file=FILE, --assume-new=FILE
                              Consider FILE to be infinitely new.
  --warn-undefined-variables  Warn when an undefined variable is referenced.

This program built for aarch64-redhat-linux-gnu
```