### PR TITLE
Release v1.0.6

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'pip'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,22 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+## 1.0.6 Jun 4 2025
+
+-f95acd1 Update github.com/golang/groupcache digest to 2c02b82
+-a4c0ee2 Update github.com/jackc/pgservicefile digest to 5a60cdf
+-2f87995 Update Konflux references (#734)
+-4a1708e updates to konflux pipeline for 1.0.5 (#756)
+-687527d Bump github.com/openshift-online/ocm-sdk-go from 0.1.463 to 0.1.465
+-de7adc6 remove marketplace-rhm option from subscription-type options (#773)
+-436ff34 secure-boot-for-shielded-vms flag for create machinepool (#778)
+-3440bb5 OCM-15127 | Add make binary in ocm-cli image (#779)
+-64ca7ac secure-boot-for-shielded-vms flag tests (#780)
+-822e0f2 Bump github.com/MicahParks/jwkset from 0.5.20 to 0.7.0 (#728)
+-8474de0 Update Konflux references
+-2ecdf68 Bump github.com/spf13/cobra from 1.7.0 to 1.9.1 (#748)
+-ea64448 Bump github.com/golang/glog from 1.2.4 to 1.2.5
+
 ## 1.0.5 Apr 4 2025
 
 -8e28c06 OCM-14358 | unbind service accounts when deleting wif-configs (#723)

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "1.0.5"
+const Version = "1.0.6"


### PR DESCRIPTION
-f95acd1 Update github.com/golang/groupcache digest to 2c02b82 -a4c0ee2 Update github.com/jackc/pgservicefile digest to 5a60cdf -2f87995 Update Konflux references (#734)
-4a1708e updates to konflux pipeline for 1.0.5 (#756) -687527d Bump github.com/openshift-online/ocm-sdk-go from 0.1.463 to 0.1.465 -de7adc6 remove marketplace-rhm option from subscription-type options (#773) -436ff34 secure-boot-for-shielded-vms flag for create machinepool (#778) -3440bb5 [OCM-15127](https://issues.redhat.com//browse/OCM-15127) | Add make binary in ocm-cli image (#779) -64ca7ac secure-boot-for-shielded-vms flag tests (#780) -822e0f2 Bump github.com/MicahParks/jwkset from 0.5.20 to 0.7.0 (#728) -8474de0 Update Konflux references
-2ecdf68 Bump github.com/spf13/cobra from 1.7.0 to 1.9.1 (#748) -ea64448 Bump github.com/golang/glog from 1.2.4 to 1.2.5