### PR TITLE
OCM-9528 | Expose FIPS flag in OCM CLI when provisioning an OSD cluster on Google Cloud

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -72,6 +72,7 @@ type Spec struct {
 	Version          string
 	ChannelGroup     string
 	Expiration       time.Time
+	Fips             bool
 	EtcdEncryption   bool
 	SubscriptionType string
 
@@ -361,6 +362,7 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec, dryRun bool) (*cmv1.Clu
 			cmv1.NewFlavour().
 				ID(config.Flavour),
 		).
+		FIPS(config.Fips).
 		EtcdEncryption(config.EtcdEncryption).
 		BillingModel(cmv1.BillingModel(config.SubscriptionType)).
 		Properties(clusterProperties)


### PR DESCRIPTION
From `-i`:
mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster -i
? Cluster name: mipereir-fips
? Subscription type: standard (Annual: Fixed capacity subscription from Red Hat)
? Cloud provider: gcp
? CCS: Yes
? Authentication type: Workload Identity Federation (WIF)
? WIF configuration: mipereir-stg (2j75tie8m8bofi0q4g338pql5isfjpuf)
? Region: us-east1
? Multiple AZ: No
? Secure boot support for Shielded VMs: No
? Use Custom KMS Keys (optional): No
? Enable FIPS cryptography: Yes
? OpenShift version:  [Use arrows to move, type to filter, ? for more help]

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster -i
? Cluster name: mipereir-fips
? Subscription type: standard (Annual: Fixed capacity subscription from Red Hat)
? Cloud provider: gcp
? CCS: Yes
? Authentication type: Workload Identity Federation (WIF)
? WIF configuration: mipereir-stg (2j75tie8m8bofi0q4g338pql5isfjpuf)
? Region: us-east1
? Multiple AZ: No
? Secure boot support for Shielded VMs: No
? Use Custom KMS Keys (optional): No
? Enable FIPS cryptography: No
? Enable additional etcd encryption: [? for help] (y/N) 

From `--help`:
--etcd-encryption        Add more encryption for OpenShift and Kubernetes API resources.
--fips                              Install a cluster that uses FIPS Validated / Modules in Process cryptographic libraries on the x86_64 architecture.

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster mipereir-fips --provider=gcp --ccs --region=us-east1 --version=openshift-v4.18.5 --wif-config=mipereir-stg --fips=true --etcd-encryption=false
Error: When FIPS mode is enabled, etcd encryption cannot be disabled

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster mipereir-fips --provider=gcp --ccs --region=us-east1 --version=openshift-v4.18.5 --wif-config=mipereir-stg --fips=true --dry-run
dry run: Would be successful.
