### PR TITLE
OCM-16225 | Cannot set param "--subscription-type", always get error

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -716,7 +716,7 @@ func preRun(cmd *cobra.Command, argv []string) error {
 
 	// Get options for subscription type
 	subscriptionTypeOptions, _ := getSubscriptionTypeOptions(connection)
-	err = arguments.PromptOrCheckOneOf(fs, "subscription-type", subscriptionTypeOptions)
+	err = arguments.PromptOneOf(fs, "subscription-type", subscriptionTypeOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster mipereir-sub --ccs=true --provider=gcp --region=us-central1 --wif-config=mipereir-stg --subscription-type=standard
ID:	2j8cevk356vjqeuel5mpfnbimc0d16no

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster mipereir-gcp --ccs=true --provider=gcp --region=us-central1 --wif-config=mipereir-stg --subscription-type=standard --dry-run
dry run: Would be successful.

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster mipereir-sub --ccs=true --provider=gcp --region=us-central1 --wif-config=mipereir-stg --subscription-type=marketplace-gcp --marketplace-gcp-terms --dry-run
setting provider to gcp
setting ccs to 'true'
dry run: Would be successful.

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster -i
```
? Cluster name: mipereir-sub-type
? Subscription type:  [Use arrows to move, type to filter, ? for more help]
> standard (Annual: Fixed capacity subscription from Red Hat)
  marketplace-gcp (On-Demand: Flexible usage billed through the Google Cloud Marketplace)
```

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster mipereir-sub --ccs=true --provider=gcp --region=us-central1 --wif-config=mipereir-stg --subscription-type=invalid-marketplace --dry-run
Error: Failed to create cluster: dry run: unable to create cluster: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400', at '2025-06-06T17:02:35Z' and operation identifier is '5a4b8ee7-9993-4bbf-b58b-ad65d492f3b5': Unknown billing model 'invalid-marketplace'. Allowed values: '[standard, marketplace, marketplace-aws, marketplace-gcp, marketplace-rhm, marketplace-azure]'.