### PR TITLE
OCM-16713 | “--availability-zones” help text incorrectly implies AWS-only support

### DIFF
--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -234,7 +234,7 @@ func AddExistingVPCFlags(fs *pflag.FlagSet, value *cluster.ExistingVPC) {
 		&value.AvailabilityZones,
 		"availability-zones",
 		nil,
-		"AWS availability zones",
+		"Cloud provider availability zones",
 	)
 	fs.StringVar(
 		&value.VPCName,


### PR DESCRIPTION
mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ./ocm create cluster -h | grep availability-zones
      --availability-zones stringArray                        Cloud provider availability zones

