### PR TITLE
OCM-18391 | feat: ensure version upgrades are taken from cluster payload

### DIFF
--- a/cmd/ocm/create/upgradepolicy/cmd.go
+++ b/cmd/ocm/create/upgradepolicy/cmd.go
@@ -155,11 +155,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	} else {
 
-		availableUpgrades, err := c.GetAvailableUpgrades(
-			connection.ClustersMgmt().V1(), c.GetVersionID(cluster), cluster.Product().ID())
-		if err != nil {
-			return fmt.Errorf("Failed to find available upgrades: %v", err)
-		}
+		availableUpgrades := c.GetAvailableUpgrades(cluster.Version())
 		if len(availableUpgrades) == 0 {
 			fmt.Println("There are no available upgrades")
 			return nil

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -869,23 +869,8 @@ func GetVersionID(cluster *cmv1.Cluster) string {
 	return cluster.Version().ID()
 }
 
-func GetAvailableUpgrades(
-	client *cmv1.Client, versionID string, productID string) ([]string, error) {
-	response, err := client.Versions().Version(versionID).Get().Send()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to find version ID %s", versionID)
-	}
-	version := response.Body()
-	availableUpgrades := version.AvailableUpgrades()
-	if productID == "ROSA" {
-		availableUpgrades, err = filterROSAVersions(
-			client, availableUpgrades, version.ChannelGroup())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return availableUpgrades, nil
+func GetAvailableUpgrades(version *cmv1.Version) []string {
+	return version.AvailableUpgrades()
 }
 
 func createVersionID(version string, channelGroup string) string {
@@ -895,23 +880,6 @@ func createVersionID(version string, channelGroup string) string {
 	}
 	return versionID
 
-}
-
-func filterROSAVersions(
-	client *cmv1.Client, versions []string, channelGroup string) ([]string, error) {
-	enabledVersions := []string{}
-	for _, version := range versions {
-		versionID := createVersionID(version, channelGroup)
-		response, err := client.Versions().Version(versionID).Get().Send()
-		if err != nil {
-			return nil, fmt.Errorf("Failed to find version ID %s", versionID)
-		}
-		rosaEnabled := response.Body().ROSAEnabled()
-		if rosaEnabled {
-			enabledVersions = append(enabledVersions, version)
-		}
-	}
-	return enabledVersions, nil
 }
 
 func cidrIsEmpty(cidr net.IPNet) bool {


### PR DESCRIPTION
Instead of the generic endpoint. This will allow introducing cluster based recommendations.

Remove also some filtering which was not used as the product ID is always lowercase.

Related: [OCM-18391](https://issues.redhat.com//browse/OCM-18391)