### PR TITLE
OCM-23391 | fix: remove ginkgo flags from CLI help output

### DIFF
--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -75,8 +75,13 @@ func init() {
 	}
 
 	// Register the options that are managed by the 'flag' package, so that they will also be parsed
-	// by the 'pflag' package:
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	// by the 'pflag' package (excluding ginkgo test flags):
+	flag.CommandLine.VisitAll(func(f *flag.Flag) {
+		// Skip ginkgo flags to keep CLI help clean
+		if !strings.HasPrefix(f.Name, "ginkgo.") {
+			pflag.CommandLine.AddGoFlag(f)
+		}
+	})
 
 	// Add the command line flags:
 	fs := root.PersistentFlags()


### PR DESCRIPTION
## Description
Filter out ginkgo test framework flags when registering command-line flags to prevent them from appearing in the CLI help messages.

## Benefits
- Cleaner, more focused help messages
- Reduced confusion for end users
- Better user experience with the CLI

## Changes
- Modified `cmd/ocm/main.go` to filter out ginkgo flags during flag registration
- Only adds flags that don't have the "ginkgo." prefix to the CLI help

## Testing
- Tested CLI help output to verify ginkgo flags no longer appear
- Verified normal CLI flags still work correctly

## Related Jira
https://issues.redhat.com/browse/OCM-23391