### PR TITLE
OCM-22609 | feat: add root-disk-size flag for cluster and machine pool creation

### DIFF
--- a/cmd/ocm/create/cluster/cmd.go
+++ b/cmd/ocm/create/cluster/cmd.go
@@ -105,6 +105,7 @@ var args struct {
 	computeMachineType string
 	computeNodes       int
 	autoscaling        c.Autoscaling
+	rootDiskSize       int
 
 	// Networking options
 	networkType string
@@ -315,6 +316,15 @@ func init() {
 		),
 	)
 	arguments.AddAutoscalingFlags(fs, &args.autoscaling)
+
+	// Note: server-side API validation handles the numerical boundaries of this flag.
+	//       client-side validation ensures the value is positive.
+	fs.IntVar(
+		&args.rootDiskSize,
+		"root-disk-size",
+		0,
+		"Root disk size in GiB for compute nodes.",
+	)
 
 	fs.StringVar(
 		&args.networkType,
@@ -746,6 +756,10 @@ func preRun(cmd *cobra.Command, argv []string) error {
 	// Validate flags / ask for missing data.
 	fs := cmd.Flags()
 
+	if cmd.Flags().Changed("root-disk-size") && args.rootDiskSize <= 0 {
+		return fmt.Errorf("--root-disk-size must be a positive value")
+	}
+
 	err = promptSubscriptionType(fs, connection)
 	if err != nil {
 		return err
@@ -1001,6 +1015,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		ComputeMachineType:   args.computeMachineType,
 		ComputeNodes:         args.computeNodes,
 		Autoscaling:          args.autoscaling,
+		RootDiskSize:         args.rootDiskSize,
 		NetworkType:          args.networkType,
 		MachineCIDR:          args.machineCIDR,
 		ServiceCIDR:          args.serviceCIDR,

--- a/cmd/ocm/create/machinepool/cmd.go
+++ b/cmd/ocm/create/machinepool/cmd.go
@@ -36,6 +36,7 @@ type Args struct {
 	AdditionalSecurityGroupIds []string
 	AvailabilityZone           string
 	SecureBoot                 bool
+	RootDiskSize               int
 }
 
 var args Args
@@ -131,6 +132,13 @@ func init() {
 		"Secure Boot enables the use of Shielded VMs in the Google Cloud Platform for the instances in this machine pool. "+
 			"This will override the cluster level configuration of secure boot.",
 	)
+
+	flags.IntVar(
+		&args.RootDiskSize,
+		"root-disk-size",
+		0,
+		"Root disk size in GiB for machine pool nodes.",
+	)
 }
 
 func run(cmd *cobra.Command, argv []string) error {
@@ -161,7 +169,7 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	machinePoolId := argv[0]
 
-	machinePool, err := buildMachinePool(machinePoolId, &flagSet{cmd.Flags()})
+	machinePool, err := buildMachinePool(machinePoolId, &flagSet{cmd.Flags()}, cluster)
 	if err != nil {
 		return err
 	}
@@ -270,12 +278,17 @@ func VerifyArguments(
 			c.ProviderGCP)
 	}
 
+	if flags.Changed("root-disk-size") && args.RootDiskSize <= 0 {
+		return fmt.Errorf("--root-disk-size must be a positive value")
+	}
+
 	return nil
 }
 
 func buildMachinePool(
 	machinePoolId string,
 	flags FlagSet,
+	cluster ocm.Cluster,
 ) (*cmv1.MachinePool, error) {
 	labels := make(map[string]string)
 	if args.Labels != "" {
@@ -325,6 +338,24 @@ func buildMachinePool(
 
 	if args.AvailabilityZone != "" {
 		mpBuilder = mpBuilder.AvailabilityZones(args.AvailabilityZone)
+	}
+
+	if args.RootDiskSize > 0 {
+		rootVolumeBuilder := cmv1.NewRootVolume()
+		// Determine provider from cluster to set appropriate root volume
+		// For now, we'll need to get the cluster provider
+		if cluster.CloudProviderId() == c.ProviderAWS {
+			rootVolumeBuilder = rootVolumeBuilder.AWS(
+				cmv1.NewAWSVolume().Size(args.RootDiskSize),
+			)
+		} else if cluster.CloudProviderId() == c.ProviderGCP {
+			rootVolumeBuilder = rootVolumeBuilder.GCP(
+				cmv1.NewGCPVolume().Size(args.RootDiskSize),
+			)
+		} else {
+			return nil, fmt.Errorf("--root-disk-size specified for unsupported cloud provider")
+		}
+		mpBuilder = mpBuilder.RootVolume(rootVolumeBuilder)
 	}
 
 	machinePool, err := mpBuilder.Build()

--- a/cmd/ocm/create/machinepool/verification_test.go
+++ b/cmd/ocm/create/machinepool/verification_test.go
@@ -232,5 +232,6 @@ func addChangedFlags(
 	mockFlagSet.EXPECT().Changed("min-replicas").MinTimes(1).Return(minReplicas)
 	mockFlagSet.EXPECT().Changed("max-replicas").MinTimes(1).Return(maxReplicas)
 	mockFlagSet.EXPECT().Changed("replicas").MinTimes(1).Return(replicas)
+	mockFlagSet.EXPECT().Changed("root-disk-size").AnyTimes().Return(false)
 	return mockFlagSet
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -86,6 +86,7 @@ type Spec struct {
 	ComputeMachineType string
 	ComputeNodes       int
 	Autoscaling        Autoscaling
+	RootDiskSize       int
 
 	// Network config
 	NetworkType string
@@ -552,12 +553,27 @@ func CreateCluster(cmv1Client *cmv1.Client, config Spec, dryRun bool) (*cmv1.Clu
 	}
 
 	if config.ComputeMachineType != "" || config.ComputeNodes > 0 || len(config.ExistingVPC.AvailabilityZones) > 0 ||
-		config.Autoscaling.Enabled {
+		config.Autoscaling.Enabled || config.RootDiskSize > 0 {
 		clusterNodesBuilder := cmv1.NewClusterNodes()
 		if config.ComputeMachineType != "" {
 			clusterNodesBuilder = clusterNodesBuilder.ComputeMachineType(
 				cmv1.NewMachineType().ID(config.ComputeMachineType),
 			)
+		}
+		if config.RootDiskSize > 0 {
+			rootVolumeBuilder := cmv1.NewRootVolume()
+			if config.Provider == ProviderAWS {
+				rootVolumeBuilder = rootVolumeBuilder.AWS(
+					cmv1.NewAWSVolume().Size(config.RootDiskSize),
+				)
+			} else if config.Provider == ProviderGCP {
+				rootVolumeBuilder = rootVolumeBuilder.GCP(
+					cmv1.NewGCPVolume().Size(config.RootDiskSize),
+				)
+			} else {
+				return nil, fmt.Errorf("--root-disk-size specified for unsupported cloud provider")
+			}
+			clusterNodesBuilder = clusterNodesBuilder.ComputeRootVolume(rootVolumeBuilder)
 		}
 		clusterNodesBuilder = buildCompute(config, clusterNodesBuilder)
 


### PR DESCRIPTION
## Summary
Add `--root-disk-size` flag to `ocm create cluster` and `ocm create machinepool` commands to allow users to specify custom root disk sizes for compute nodes.

## Changes
- Added `--root-disk-size` flag to `create cluster` command
- Added `--root-disk-size` flag to `create machinepool` command  
- Updated cluster package to support root disk size configuration
- Supports both AWS and GCP providers with appropriate volume configurations

## Test plan
- Manual testing in sandbox environment
- Verify flag appears in help output for both commands
- Test cluster creation with custom root disk size
- Test machine pool creation with custom root disk size

🤖 Generated with [Claude Code](https://claude.com/claude-code)