### PR TITLE
Release v1.0.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 This document describes the relevant changes between releases of the
 `ocm` command line tool.
 
+## 1.0.14 Apr 22 2026
+
+- OCM-23391 | fix: remove ginkgo flags from CLI help output
+- OCM-22609 | feat: add root-disk-size flag for cluster and machine pool creation
+- OCM-23128 | chore: bump google.golang.org/grpc from 1.77.0 to 1.79.3
+
 ## 1.0.13 Apr 2 2026
 
 - OCM-21285 | feat: day-1 support for default ingress excluded namespace selectors

--- a/pkg/info/info.go
+++ b/pkg/info/info.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package info
 
-const Version = "1.0.13"
+const Version = "1.0.14"


### PR DESCRIPTION
- [OCM-23391](https://redhat.atlassian.net/browse/OCM-23391) | fix: remove ginkgo flags from CLI help output
- [OCM-22609](https://redhat.atlassian.net/browse/OCM-22609) | feat: add root-disk-size flag for cluster and machine pool creation
- [OCM-23128](https://redhat.atlassian.net/browse/OCM-23128) | chore: bump google.golang.org/grpc from 1.77.0 to 1.79.3