### PR TITLE
Support opaque (non-JWT) tokens for sandbox environments

### DIFF
--- a/cmd/ocm/login/cmd.go
+++ b/cmd/ocm/login/cmd.go
@@ -256,6 +256,11 @@ func run(cmd *cobra.Command, argv []string) error {
 		if config.IsEncryptedToken(args.token) {
 			cfg.AccessToken = ""
 			cfg.RefreshToken = args.token
+		} else if !config.IsJWTToken(args.token) {
+			// Opaque tokens can't be parsed, so we treat them as access tokens
+			// and let the server decide if they're valid.
+			cfg.AccessToken = args.token
+			cfg.RefreshToken = ""
 		} else {
 			// If a token has been provided parse it:
 			token, err := config.ParseToken(args.token)
@@ -329,20 +334,22 @@ func run(cmd *cobra.Command, argv []string) error {
 	cfg.Password = args.password
 	cfg.Insecure = args.insecure
 
-	// Create a connection and get the token to verify that the crendentials are correct:
-	connection, err := ocm.NewConnection().Config(cfg).Build()
-	if err != nil {
-		return fmt.Errorf("Can't create connection: %v", err)
-	}
-	accessToken, refreshToken, err := connection.Tokens()
-	if err != nil {
-		return fmt.Errorf("Can't get token: %v", err)
+	if !config.IsOpaqueToken(cfg.AccessToken) {
+		// Create a connection and get the token to verify that the credentials are correct:
+		connection, err := ocm.NewConnection().Config(cfg).Build()
+		if err != nil {
+			return fmt.Errorf("Can't create connection: %v", err)
+		}
+		accessToken, refreshToken, err := connection.Tokens()
+		if err != nil {
+			return fmt.Errorf("Can't get token: %v", err)
+		}
+		cfg.AccessToken = accessToken
+		cfg.RefreshToken = refreshToken
 	}
 
 	// Save the configuration, but clear the user name and password before unless we have
 	// explicitly been asked to store them persistently:
-	cfg.AccessToken = accessToken
-	cfg.RefreshToken = refreshToken
 	if !args.persistent {
 		cfg.User = ""
 		cfg.Password = ""

--- a/cmd/ocm/token/cmd.go
+++ b/cmd/ocm/token/cmd.go
@@ -100,27 +100,53 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Options '--payload', '--header', '--signature', and '--generate' are mutually exclusive")
 	}
 
-	// Create the client for the OCM API:
-	connection, err := ocm.NewConnection().Build()
+	// Load the configuration file:
+	cfg, err := config.Load()
 	if err != nil {
-		return fmt.Errorf("Failed to create OCM connection: %v", err)
+		return fmt.Errorf("Can't load config file: %v", err)
 	}
-	defer connection.Close()
 
 	var accessToken string
 	var refreshToken string
 
-	if args.generate {
-		// Get new tokens:
-		accessToken, refreshToken, err = connection.Tokens(15 * time.Minute)
-		if err != nil {
-			return fmt.Errorf("Can't get new tokens: %v", err)
+	// For opaque tokens, the SDK's unauthenticated connection can't manage
+	// tokens via connection.Tokens(), so read them from config directly.
+	haveOpaqueToken := cfg != nil && config.IsOpaqueToken(cfg.AccessToken)
+
+	if haveOpaqueToken {
+		if args.generate {
+			return fmt.Errorf("The '--generate' option is not supported with opaque tokens")
 		}
+		accessToken = cfg.AccessToken
+		refreshToken = cfg.RefreshToken
 	} else {
-		// Get the tokens:
-		accessToken, refreshToken, err = connection.Tokens()
+		// Create the client for the OCM API:
+		connection, err := ocm.NewConnection().Build()
 		if err != nil {
-			return fmt.Errorf("Can't get token: %v", err)
+			return fmt.Errorf("Failed to create OCM connection: %v", err)
+		}
+		defer connection.Close()
+
+		if args.generate {
+			// Get new tokens:
+			accessToken, refreshToken, err = connection.Tokens(15 * time.Minute)
+			if err != nil {
+				return fmt.Errorf("Can't get new tokens: %v", err)
+			}
+		} else {
+			// Get the tokens:
+			accessToken, refreshToken, err = connection.Tokens()
+			if err != nil {
+				return fmt.Errorf("Can't get token: %v", err)
+			}
+		}
+
+		// Save the potentially refreshed tokens:
+		cfg.AccessToken = accessToken
+		cfg.RefreshToken = refreshToken
+		err = config.Save(cfg)
+		if err != nil {
+			return fmt.Errorf("Can't save config file: %v", err)
 		}
 	}
 
@@ -130,58 +156,53 @@ func run(cmd *cobra.Command, argv []string) error {
 		selectedToken = refreshToken
 	}
 
-	// Parse the token:
-	parser := new(jwt.Parser)
-	_, parts, err := parser.ParseUnverified(selectedToken, jwt.MapClaims{})
-	if err != nil {
-		return fmt.Errorf("Can't parse token: %v", err)
-	}
-	encoding := base64.RawURLEncoding
-	header, err := encoding.DecodeString(parts[0])
-	if err != nil {
-		return fmt.Errorf("Can't decode header: %v", err)
-	}
-	payload, err := encoding.DecodeString(parts[1])
-	if err != nil {
-		return fmt.Errorf("Can't decode payload: %v", err)
-	}
-	signature, err := encoding.DecodeString(parts[2])
-	if err != nil {
-		return fmt.Errorf("Can't decode signature: %v", err)
-	}
-
-	// Print the data:
-	if args.header {
-		err = dump.Pretty(os.Stdout, header)
-		if err != nil {
-			return fmt.Errorf("Can't dump header: %v", err)
+	if !config.IsJWTToken(selectedToken) {
+		if args.header || args.payload || args.signature {
+			return fmt.Errorf(
+				"The token is not a JWT, so '--header', '--payload', and '--signature' options are not available",
+			)
 		}
-	} else if args.payload {
-		err = dump.Pretty(os.Stdout, payload)
-		if err != nil {
-			return fmt.Errorf("Can't dump payload: %v", err)
-		}
-	} else if args.signature {
-		err = dump.Pretty(os.Stdout, signature)
-		if err != nil {
-			return fmt.Errorf("Can't dump signature: %v", err)
-		}
-	} else {
 		fmt.Fprintf(os.Stdout, "%s\n", selectedToken)
-	}
+	} else {
+		// Parse the token:
+		parser := new(jwt.Parser)
+		_, parts, err := parser.ParseUnverified(selectedToken, jwt.MapClaims{})
+		if err != nil {
+			return fmt.Errorf("Can't parse token: %v", err)
+		}
+		encoding := base64.RawURLEncoding
+		header, err := encoding.DecodeString(parts[0])
+		if err != nil {
+			return fmt.Errorf("Can't decode header: %v", err)
+		}
+		payload, err := encoding.DecodeString(parts[1])
+		if err != nil {
+			return fmt.Errorf("Can't decode payload: %v", err)
+		}
+		signature, err := encoding.DecodeString(parts[2])
+		if err != nil {
+			return fmt.Errorf("Can't decode signature: %v", err)
+		}
 
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
-	}
-
-	// Save the configuration:
-	cfg.AccessToken = accessToken
-	cfg.RefreshToken = refreshToken
-	err = config.Save(cfg)
-	if err != nil {
-		return fmt.Errorf("Can't save config file: %v", err)
+		// Print the data:
+		if args.header {
+			err = dump.Pretty(os.Stdout, header)
+			if err != nil {
+				return fmt.Errorf("Can't dump header: %v", err)
+			}
+		} else if args.payload {
+			err = dump.Pretty(os.Stdout, payload)
+			if err != nil {
+				return fmt.Errorf("Can't dump payload: %v", err)
+			}
+		} else if args.signature {
+			err = dump.Pretty(os.Stdout, signature)
+			if err != nil {
+				return fmt.Errorf("Can't dump signature: %v", err)
+			}
+		} else {
+			fmt.Fprintf(os.Stdout, "%s\n", selectedToken)
+		}
 	}
 
 	// Bye:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -174,4 +174,66 @@ var _ = Describe("Armed", func() {
 		Expect(armed).To(BeFalse())
 		Expect(reason).To(Equal("credentials aren't set"))
 	})
+
+	It("Is armed if contains an opaque access token", func() {
+		config := &Config{
+			AccessToken: "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729",
+			URL:         "http://my-server.example.com",
+			TokenURL:    "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+
+	It("Is armed if contains an opaque refresh token", func() {
+		config := &Config{
+			RefreshToken: "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729",
+			URL:          "http://my-server.example.com",
+			TokenURL:     "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+})
+
+var _ = Describe("IsOpaqueToken", func() {
+	It("Returns true for an opaque token without dots", func() {
+		Expect(IsOpaqueToken("GONDOLIN_SECRET_d5bfa746c20ab8140fae5729")).To(BeTrue())
+	})
+
+	It("Returns false for a standard 3-segment JWT", func() {
+		token := MakeTokenString("Bearer", 15*time.Minute)
+		Expect(IsOpaqueToken(token)).To(BeFalse())
+	})
+
+	It("Returns false for an empty string", func() {
+		Expect(IsOpaqueToken("")).To(BeFalse())
+	})
+})
+
+var _ = Describe("IsJWTToken", func() {
+	It("Returns true for a standard 3-segment JWT", func() {
+		token := MakeTokenString("Bearer", 15*time.Minute)
+		Expect(IsJWTToken(token)).To(BeTrue())
+	})
+
+	It("Returns false for an opaque token without dots", func() {
+		Expect(IsJWTToken("GONDOLIN_SECRET_d5bfa746c20ab8140fae5729")).To(BeFalse())
+	})
+
+	It("Returns false for a token with one dot", func() {
+		Expect(IsJWTToken("some.token")).To(BeFalse())
+	})
+
+	It("Returns false for a 5-segment JWE token", func() {
+		Expect(IsJWTToken("a.b.c.d.e")).To(BeFalse())
+	})
+
+	It("Returns false for an empty string", func() {
+		Expect(IsJWTToken("")).To(BeFalse())
+	})
 })

--- a/pkg/config/token.go
+++ b/pkg/config/token.go
@@ -53,6 +53,15 @@ func IsEncryptedToken(textToken string) bool {
 	return false
 }
 
+func IsJWTToken(textToken string) bool {
+	parts := strings.Split(textToken, ".")
+	return len(parts) == 3
+}
+
+func IsOpaqueToken(textToken string) bool {
+	return textToken != "" && !IsJWTToken(textToken) && !IsEncryptedToken(textToken)
+}
+
 func ParseToken(textToken string) (token *jwt.Token, err error) {
 	parser := new(jwt.Parser)
 	token, _, err = parser.ParseUnverified(textToken, jwt.MapClaims{})
@@ -64,6 +73,12 @@ func ParseToken(textToken string) (token *jwt.Token, err error) {
 
 // tokenUsable checks if the given token is usable.
 func tokenUsable(token string, margin time.Duration) (usable bool, err error) {
+	if !IsJWTToken(token) {
+		// We have no way of knowing an opaque token's expiration, so
+		// we assume it's valid and let the server decide.
+		usable = true
+		return
+	}
 	parsed, err := ParseToken(token)
 	if err != nil {
 		return

--- a/pkg/ocm/connection-builder/connection.go
+++ b/pkg/ocm/connection-builder/connection.go
@@ -15,6 +15,7 @@ package connection
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-common/pkg/deprecation"
@@ -118,8 +119,23 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 	return builder.Build()
 }
 
+func (b *ConnectionBuilder) hasOpaqueAccessToken() bool {
+	return config.IsOpaqueToken(b.cfg.AccessToken)
+}
+
 func (b *ConnectionBuilder) initConnectionBuilderFromConfig() *sdk.ConnectionBuilder {
-	builder := sdk.NewConnectionBuilder()
+	opaqueToken := b.hasOpaqueAccessToken()
+
+	var builder *sdk.ConnectionBuilder
+	if opaqueToken {
+		builder = sdk.NewUnauthenticatedConnectionBuilder()
+		token := b.cfg.AccessToken
+		builder.TransportWrapper(func(wrapped http.RoundTripper) http.RoundTripper {
+			return &opaqueTokenTransport{next: wrapped, token: token}
+		})
+	} else {
+		builder = sdk.NewConnectionBuilder()
+	}
 
 	// Add deprecation transport wrapper to automatically handle deprecation headers
 	builder.TransportWrapper(deprecation.NewTransportWrapper())
@@ -141,19 +157,33 @@ func (b *ConnectionBuilder) initConnectionBuilderFromConfig() *sdk.ConnectionBui
 	if b.cfg.URL != "" {
 		builder.URL(b.cfg.URL)
 	}
-	tokens := make([]string, 0, 2)
-	if b.cfg.AccessToken != "" {
-		tokens = append(tokens, b.cfg.AccessToken)
-	}
-	if b.cfg.RefreshToken != "" {
-		tokens = append(tokens, b.cfg.RefreshToken)
-	}
-	if len(tokens) > 0 {
-		builder.Tokens(tokens...)
+	if !opaqueToken {
+		tokens := make([]string, 0, 2)
+		if b.cfg.AccessToken != "" {
+			tokens = append(tokens, b.cfg.AccessToken)
+		}
+		if b.cfg.RefreshToken != "" {
+			tokens = append(tokens, b.cfg.RefreshToken)
+		}
+		if len(tokens) > 0 {
+			builder.Tokens(tokens...)
+		}
 	}
 	builder.Insecure(b.cfg.Insecure)
 
 	return builder
+}
+
+// opaqueTokenTransport injects an Authorization header for opaque (non-JWT)
+// tokens, bypassing the SDK's built-in token management.
+type opaqueTokenTransport struct {
+	next  http.RoundTripper
+	token string
+}
+
+func (t *opaqueTokenTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	request.Header.Set("Authorization", "Bearer "+t.token)
+	return t.next.RoundTrip(request)
 }
 
 // Returns the configured logger or a default if there is none configured

--- a/tests/login_test.go
+++ b/tests/login_test.go
@@ -112,6 +112,43 @@ var _ = Describe("Login", func() {
 		})
 	})
 
+	When("Using opaque token", func() {
+		It("Creates the configuration file", func() {
+			opaqueToken := "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729"
+
+			result := NewCommand().
+				Args(
+					"login",
+					"--token", opaqueToken,
+					"--token-url", ssoServer.URL(),
+				).
+				Run(ctx)
+
+			Expect(result.ExitCode()).To(BeZero())
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(result.ConfigFile()).ToNot(BeEmpty())
+			Expect(result.ConfigString()).To(MatchJSONTemplate(
+				`{
+					"url": "{{ .url }}",
+					"token_url": "{{ .tokenURL }}",
+					"client_id": "{{ .clientID }}",
+					"scopes": [
+						{{ range $i, $scope := .scopes }}
+							{{ if gt $i 0 }},{{ end }}
+							"{{ $scope }}"
+						{{ end }}
+					],
+					"access_token": "{{ .accessToken }}"
+				}`,
+				"url", sdk.DefaultURL,
+				"tokenURL", ssoServer.URL(),
+				"clientID", sdk.DefaultClientID,
+				"scopes", sdk.DefaultScopes,
+				"accessToken", opaqueToken,
+			))
+		})
+	})
+
 	When("Using client credentials grant", func() {
 		It("Creates the configuration file", func() {
 			// Create the token:

--- a/tests/token_test.go
+++ b/tests/token_test.go
@@ -73,6 +73,75 @@ var _ = Describe("Token", func() {
 		})
 	})
 
+	When("Logged in with opaque token", func() {
+		var opaqueToken string
+
+		BeforeEach(func() {
+			opaqueToken = "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729"
+			cmd = NewCommand().
+				ConfigString(
+					`{
+						"access_token": "{{ .accessToken }}",
+						"url": "http://my-server.example.com",
+						"token_url": "http://my-sso.example.com"
+					}`,
+					"accessToken", opaqueToken,
+				).
+				Arg("token")
+		})
+
+		It("Displays the opaque access token", func() {
+			result := cmd.Run(ctx)
+			Expect(result.OutString()).To(Equal(opaqueToken + "\n"))
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(result.ExitCode()).To(BeZero())
+		})
+
+		It("Displays the opaque refresh token", func() {
+			refreshToken := "GONDOLIN_REFRESH_abc123"
+			cmd = NewCommand().
+				ConfigString(
+					`{
+						"access_token": "{{ .accessToken }}",
+						"refresh_token": "{{ .refreshToken }}",
+						"url": "http://my-server.example.com",
+						"token_url": "http://my-sso.example.com"
+					}`,
+					"accessToken", opaqueToken,
+					"refreshToken", refreshToken,
+				).
+				Args("token", "--refresh")
+			result := cmd.Run(ctx)
+			Expect(result.OutString()).To(Equal(refreshToken + "\n"))
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(result.ExitCode()).To(BeZero())
+		})
+
+		It("Rejects --header for opaque tokens", func() {
+			result := cmd.Arg("--header").Run(ctx)
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("not a JWT"))
+		})
+
+		It("Rejects --payload for opaque tokens", func() {
+			result := cmd.Arg("--payload").Run(ctx)
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("not a JWT"))
+		})
+
+		It("Rejects --signature for opaque tokens", func() {
+			result := cmd.Arg("--signature").Run(ctx)
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("not a JWT"))
+		})
+
+		It("Rejects --generate for opaque tokens", func() {
+			result := cmd.Arg("--generate").Run(ctx)
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("opaque tokens"))
+		})
+	})
+
 	When("Not logged in", func() {
 		BeforeEach(func() {
 			cmd = NewCommand().Arg("token")


### PR DESCRIPTION
**Superseded by #1116** 

## Summary

- Add `IsJWTToken()` and `IsOpaqueToken()` helpers to detect token types and skip JWT parsing for opaque tokens
- In `tokenUsable()`, assume opaque tokens are valid and let the server decide (matching the existing pattern for encrypted JWE tokens)
- In the login command, treat opaque tokens as access tokens and skip `connection.Tokens()` which returns empty strings for unauthenticated connections
- In the token command, print opaque tokens raw and return a clear error when `--header`/`--payload`/`--signature`/`--generate` flags are used with non-JWT tokens
- In the connection builder, use `NewUnauthenticatedConnectionBuilder()` with a custom transport wrapper that injects the `Authorization: Bearer` header for opaque tokens

## Context

Sandbox environments like OpenShell and Gondolin issue opaque access tokens (e.g. `GONDOLIN_SECRET_...`) rather than JWTs. Previously, the CLI unconditionally parsed all tokens as JWTs via `jwt.ParseUnverified()`, causing every command to fail with `"token contains an invalid number of segments"`.

## Test plan

- [x] Unit tests for `IsJWTToken()` covering JWT, opaque, JWE, and empty strings
- [x] Unit tests for `IsOpaqueToken()` covering opaque, JWT, and empty strings
- [x] Unit tests for `Armed()` with opaque access and refresh tokens
- [x] Integration tests for `ocm token` with opaque tokens (display, --refresh, --header, --payload, --signature, --generate)
- [x] Integration test for `ocm login` with opaque token (config file creation)
- [x] Manual verification in a sandbox environment with an opaque token

Generated with [Claude Code](https://claude.com/claude-code)