### PR TITLE
Support opaque (non-JWT) tokens for sandbox environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,39 @@ as an alternative to storing the configuration in plain-text on your system.
 | macOS  | :x:  | :heavy_check_mark:*  | :x:  | :heavy_check_mark:  |
 | Linux  | :x:  | :x:  | :heavy_check_mark: | :heavy_check_mark: |
 
+## Using Opaque (Non-JWT) Tokens
+
+Some environments use opaque tokens that are not JWTs. The `ocm` CLI supports
+these tokens in two ways.
+
+### Per-invocation mode
+
+Pass the `--opaque-token` flag or set the `OCM_OPAQUE_TOKEN=true` environment
+variable. This tells the CLI to send the stored access token as-is without
+attempting JWT parsing or refresh:
+
+```
+$ ocm --opaque-token get /api/clusters_mgmt/v1/clusters
+```
+
+or:
+
+```
+$ export OCM_OPAQUE_TOKEN=true
+$ ocm get /api/clusters_mgmt/v1/clusters
+```
+
+### Persistent mode
+
+To store an opaque token in the configuration file so you do not need the flag
+on every invocation: `ocm config set opaque_token true`.
+
+When `opaque_token` is set in the configuration, the CLI will skip token
+refresh and JWT parsing for all commands.
+
+Note: the `--opaque-token` flag is not used with `ocm login`. Log in normally
+first, then configure the opaque token as shown above.
+
 ## Obtaining Tokens
 
 If you need the _OpenID_ access token to use it with some other tool, you can

--- a/cmd/ocm/config/get/get.go
+++ b/cmd/ocm/config/get/get.go
@@ -71,6 +71,8 @@ func run(cmd *cobra.Command, argv []string) error {
 		fmt.Fprintf(os.Stdout, "%s\n", cfg.ClientSecret)
 	case "insecure":
 		fmt.Fprintf(os.Stdout, "%v\n", cfg.Insecure)
+	case "opaque_token":
+		fmt.Fprintf(os.Stdout, "%v\n", cfg.OpaqueToken)
 	case "password":
 		fmt.Fprintf(os.Stdout, "%s\n", cfg.Password)
 	case "refresh_token":

--- a/cmd/ocm/config/set/set.go
+++ b/cmd/ocm/config/set/set.go
@@ -74,6 +74,11 @@ func run(cmd *cobra.Command, argv []string) error {
 		if err != nil {
 			return fmt.Errorf("Failed to set insecure: %v", value)
 		}
+	case "opaque_token":
+		cfg.OpaqueToken, err = strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("Failed to set opaque_token: %v", value)
+		}
 	case "password":
 		cfg.Password = value
 	case "refresh_token":

--- a/cmd/ocm/delete/cmd.go
+++ b/cmd/ocm/delete/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift-online/ocm-cli/pkg/opaquetoken"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
@@ -99,6 +100,15 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("could not create URI: %w", err)
 	}
 
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("can't load config file: %w", err)
+	}
+	if cfg == nil {
+		return fmt.Errorf("not logged in, run the 'login' command")
+	}
+
 	// Create the client for the OCM API:
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
@@ -132,23 +142,16 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("can't print body: %w", err)
 	}
 
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("can't load config file: %w", err)
-	}
-	if cfg == nil {
-		return fmt.Errorf("not logged in, run the 'login' command")
-	}
-
-	// Save the configuration:
-	cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
-	if err != nil {
-		return fmt.Errorf("can't get tokens: %w", err)
-	}
-	err = config.Save(cfg)
-	if err != nil {
-		return fmt.Errorf("can't save config file: %w", err)
+	// Save the configuration (skip for opaque tokens since the SDK does not manage them):
+	if !(cfg.OpaqueToken || opaquetoken.Enabled()) {
+		cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
+		if err != nil {
+			return fmt.Errorf("can't get tokens: %w", err)
+		}
+		err = config.Save(cfg)
+		if err != nil {
+			return fmt.Errorf("can't save config file: %w", err)
+		}
 	}
 
 	// Bye:

--- a/cmd/ocm/get/cmd.go
+++ b/cmd/ocm/get/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift-online/ocm-cli/pkg/opaquetoken"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
@@ -111,14 +112,16 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Can't print body: %v", err)
 	}
 
-	// Save the configuration:
-	cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
-	if err != nil {
-		return fmt.Errorf("Can't get tokens: %v", err)
-	}
-	err = config.Save(cfg)
-	if err != nil {
-		return fmt.Errorf("Can't save config file: %v", err)
+	// Save the configuration (skip for opaque tokens since the SDK does not manage them):
+	if !(cfg.OpaqueToken || opaquetoken.Enabled()) {
+		cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
+		if err != nil {
+			return fmt.Errorf("Can't get tokens: %v", err)
+		}
+		err = config.Save(cfg)
+		if err != nil {
+			return fmt.Errorf("Can't save config file: %v", err)
+		}
 	}
 
 	// Bye:

--- a/cmd/ocm/login/cmd.go
+++ b/cmd/ocm/login/cmd.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift-online/ocm-cli/pkg/opaquetoken"
 	"github.com/openshift-online/ocm-cli/pkg/properties"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -182,6 +183,16 @@ func run(cmd *cobra.Command, argv []string) error {
 		}
 	}
 
+	if opaquetoken.Enabled() {
+		return fmt.Errorf(
+			"The '--opaque-token' flag and '%s' environment variable are not used with "+
+				"the login command. To use an opaque token, first log in normally, then run:\n"+
+				"  ocm config set access_token <your-opaque-token>\n"+
+				"  ocm config set opaque_token true",
+			properties.OpaqueTokenEnvKey,
+		)
+	}
+
 	if args.useAuthCode {
 		fmt.Println("You will now be redirected to Red Hat SSO login")
 		// Short wait for a less jarring experience
@@ -252,7 +263,6 @@ func run(cmd *cobra.Command, argv []string) error {
 	}
 
 	if haveToken {
-		// Encrypted tokens are assumed to be refresh tokens:
 		if config.IsEncryptedToken(args.token) {
 			cfg.AccessToken = ""
 			cfg.RefreshToken = args.token
@@ -278,7 +288,6 @@ func run(cmd *cobra.Command, argv []string) error {
 				return fmt.Errorf("Don't know how to handle token type '%s' in token '%s'", typ, args.token)
 			}
 		}
-
 	}
 
 	// Apply the default OpenID details if not explicitly provided by the user:
@@ -329,7 +338,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	cfg.Password = args.password
 	cfg.Insecure = args.insecure
 
-	// Create a connection and get the token to verify that the crendentials are correct:
+	// Create a connection and get the token to verify that the credentials are correct:
 	connection, err := ocm.NewConnection().Config(cfg).Build()
 	if err != nil {
 		return fmt.Errorf("Can't create connection: %v", err)
@@ -338,11 +347,11 @@ func run(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("Can't get token: %v", err)
 	}
+	cfg.AccessToken = accessToken
+	cfg.RefreshToken = refreshToken
 
 	// Save the configuration, but clear the user name and password before unless we have
 	// explicitly been asked to store them persistently:
-	cfg.AccessToken = accessToken
-	cfg.RefreshToken = refreshToken
 	if !args.persistent {
 		cfg.User = ""
 		cfg.Password = ""

--- a/cmd/ocm/main.go
+++ b/cmd/ocm/main.go
@@ -86,6 +86,7 @@ func init() {
 	// Add the command line flags:
 	fs := root.PersistentFlags()
 	arguments.AddDebugFlag(fs)
+	arguments.AddOpaqueTokenFlag(fs)
 
 	// Register the subcommands:
 	root.AddCommand(account.Cmd)

--- a/cmd/ocm/patch/cmd.go
+++ b/cmd/ocm/patch/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift-online/ocm-cli/pkg/opaquetoken"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
@@ -54,6 +55,15 @@ func run(cmd *cobra.Command, argv []string) error {
 	path, err := urls.Expand(argv)
 	if err != nil {
 		return fmt.Errorf("Could not create URI: %v", err)
+	}
+
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("Can't load config file: %v", err)
+	}
+	if cfg == nil {
+		return fmt.Errorf("Not logged in, run the 'login' command")
 	}
 
 	// Create the client for the OCM API:
@@ -92,19 +102,16 @@ func run(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("Can't print body: %v", err)
 	}
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
-	}
-	// Save the configuration:
-	cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
-	if err != nil {
-		return fmt.Errorf("Can't get tokens: %v", err)
-	}
-	err = config.Save(cfg)
-	if err != nil {
-		return fmt.Errorf("Can't save config file: %v", err)
+	// Save the configuration (skip for opaque tokens since the SDK does not manage them):
+	if !(cfg.OpaqueToken || opaquetoken.Enabled()) {
+		cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
+		if err != nil {
+			return fmt.Errorf("Can't get tokens: %v", err)
+		}
+		err = config.Save(cfg)
+		if err != nil {
+			return fmt.Errorf("Can't save config file: %v", err)
+		}
 	}
 
 	// Bye:

--- a/cmd/ocm/post/cmd.go
+++ b/cmd/ocm/post/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift-online/ocm-cli/pkg/opaquetoken"
 	"github.com/openshift-online/ocm-cli/pkg/urls"
 )
 
@@ -54,6 +55,15 @@ func run(cmd *cobra.Command, argv []string) error {
 	path, err := urls.Expand(argv)
 	if err != nil {
 		return fmt.Errorf("Could not create URI: %v", err)
+	}
+
+	// Load the configuration file:
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("Can't load config file: %v", err)
+	}
+	if cfg == nil {
+		return fmt.Errorf("Not logged in, run the 'login' command")
 	}
 
 	// Create the client for the OCM API:
@@ -93,19 +103,16 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Can't print body: %v", err)
 	}
 
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
-	}
-	// Save the configuration:
-	cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
-	if err != nil {
-		return fmt.Errorf("Can't get tokens: %v", err)
-	}
-	err = config.Save(cfg)
-	if err != nil {
-		return fmt.Errorf("Can't save config file: %v", err)
+	// Save the configuration (skip for opaque tokens since the SDK does not manage them):
+	if !(cfg.OpaqueToken || opaquetoken.Enabled()) {
+		cfg.AccessToken, cfg.RefreshToken, err = connection.Tokens()
+		if err != nil {
+			return fmt.Errorf("Can't get tokens: %v", err)
+		}
+		err = config.Save(cfg)
+		if err != nil {
+			return fmt.Errorf("Can't save config file: %v", err)
+		}
 	}
 
 	// Bye:

--- a/cmd/ocm/token/cmd.go
+++ b/cmd/ocm/token/cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift-online/ocm-cli/pkg/opaquetoken"
 )
 
 var args struct {
@@ -100,27 +101,51 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("Options '--payload', '--header', '--signature', and '--generate' are mutually exclusive")
 	}
 
-	// Create the client for the OCM API:
-	connection, err := ocm.NewConnection().Build()
+	// Load the configuration file:
+	cfg, err := config.Load()
 	if err != nil {
-		return fmt.Errorf("Failed to create OCM connection: %v", err)
+		return fmt.Errorf("Can't load config file: %v", err)
 	}
-	defer connection.Close()
 
 	var accessToken string
 	var refreshToken string
 
-	if args.generate {
-		// Get new tokens:
-		accessToken, refreshToken, err = connection.Tokens(15 * time.Minute)
-		if err != nil {
-			return fmt.Errorf("Can't get new tokens: %v", err)
+	haveOpaqueToken := opaquetoken.Enabled() || (cfg != nil && cfg.OpaqueToken)
+
+	if haveOpaqueToken {
+		if args.generate {
+			return fmt.Errorf("The '--generate' option is not supported with opaque tokens")
 		}
+		accessToken = cfg.AccessToken
+		refreshToken = cfg.RefreshToken
 	} else {
-		// Get the tokens:
-		accessToken, refreshToken, err = connection.Tokens()
+		// Create the client for the OCM API:
+		connection, err := ocm.NewConnection().Build()
 		if err != nil {
-			return fmt.Errorf("Can't get token: %v", err)
+			return fmt.Errorf("Failed to create OCM connection: %v", err)
+		}
+		defer connection.Close()
+
+		if args.generate {
+			// Get new tokens:
+			accessToken, refreshToken, err = connection.Tokens(15 * time.Minute)
+			if err != nil {
+				return fmt.Errorf("Can't get new tokens: %v", err)
+			}
+		} else {
+			// Get the tokens:
+			accessToken, refreshToken, err = connection.Tokens()
+			if err != nil {
+				return fmt.Errorf("Can't get token: %v", err)
+			}
+		}
+
+		// Save the potentially refreshed tokens:
+		cfg.AccessToken = accessToken
+		cfg.RefreshToken = refreshToken
+		err = config.Save(cfg)
+		if err != nil {
+			return fmt.Errorf("Can't save config file: %v", err)
 		}
 	}
 
@@ -130,58 +155,49 @@ func run(cmd *cobra.Command, argv []string) error {
 		selectedToken = refreshToken
 	}
 
-	// Parse the token:
-	parser := new(jwt.Parser)
-	_, parts, err := parser.ParseUnverified(selectedToken, jwt.MapClaims{})
-	if err != nil {
-		return fmt.Errorf("Can't parse token: %v", err)
-	}
-	encoding := base64.RawURLEncoding
-	header, err := encoding.DecodeString(parts[0])
-	if err != nil {
-		return fmt.Errorf("Can't decode header: %v", err)
-	}
-	payload, err := encoding.DecodeString(parts[1])
-	if err != nil {
-		return fmt.Errorf("Can't decode payload: %v", err)
-	}
-	signature, err := encoding.DecodeString(parts[2])
-	if err != nil {
-		return fmt.Errorf("Can't decode signature: %v", err)
-	}
-
-	// Print the data:
-	if args.header {
-		err = dump.Pretty(os.Stdout, header)
-		if err != nil {
-			return fmt.Errorf("Can't dump header: %v", err)
+	if args.header || args.payload || args.signature {
+		if !config.IsJWTToken(selectedToken) {
+			return fmt.Errorf(
+				"The token is not a JWT, so '--header', '--payload', and '--signature' options are not available",
+			)
 		}
-	} else if args.payload {
-		err = dump.Pretty(os.Stdout, payload)
+		// Parse the token:
+		parser := new(jwt.Parser)
+		_, parts, err := parser.ParseUnverified(selectedToken, jwt.MapClaims{})
 		if err != nil {
-			return fmt.Errorf("Can't dump payload: %v", err)
+			return fmt.Errorf("Can't parse token: %v", err)
 		}
-	} else if args.signature {
-		err = dump.Pretty(os.Stdout, signature)
-		if err != nil {
-			return fmt.Errorf("Can't dump signature: %v", err)
+		encoding := base64.RawURLEncoding
+		if args.header {
+			decoded, err := encoding.DecodeString(parts[0])
+			if err != nil {
+				return fmt.Errorf("Can't decode header: %v", err)
+			}
+			err = dump.Pretty(os.Stdout, decoded)
+			if err != nil {
+				return fmt.Errorf("Can't dump header: %v", err)
+			}
+		} else if args.payload {
+			decoded, err := encoding.DecodeString(parts[1])
+			if err != nil {
+				return fmt.Errorf("Can't decode payload: %v", err)
+			}
+			err = dump.Pretty(os.Stdout, decoded)
+			if err != nil {
+				return fmt.Errorf("Can't dump payload: %v", err)
+			}
+		} else if args.signature {
+			decoded, err := encoding.DecodeString(parts[2])
+			if err != nil {
+				return fmt.Errorf("Can't decode signature: %v", err)
+			}
+			err = dump.Pretty(os.Stdout, decoded)
+			if err != nil {
+				return fmt.Errorf("Can't dump signature: %v", err)
+			}
 		}
 	} else {
 		fmt.Fprintf(os.Stdout, "%s\n", selectedToken)
-	}
-
-	// Load the configuration file:
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("Can't load config file: %v", err)
-	}
-
-	// Save the configuration:
-	cfg.AccessToken = accessToken
-	cfg.RefreshToken = refreshToken
-	err = config.Save(cfg)
-	if err != nil {
-		return fmt.Errorf("Can't save config file: %v", err)
 	}
 
 	// Bye:

--- a/pkg/arguments/arguments.go
+++ b/pkg/arguments/arguments.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/openshift-online/ocm-cli/pkg/cluster"
 	"github.com/openshift-online/ocm-cli/pkg/debug"
+	"github.com/openshift-online/ocm-cli/pkg/opaquetoken"
 	"github.com/openshift-online/ocm-cli/pkg/output"
 )
 
@@ -56,6 +57,11 @@ func (f *FilePath) Type() string {
 // AddDebugFlag adds the '--debug' flag to the given set of command line flags.
 func AddDebugFlag(fs *pflag.FlagSet) {
 	debug.AddFlag(fs)
+}
+
+// AddOpaqueTokenFlag adds the '--opaque-token' flag to the given set of command line flags.
+func AddOpaqueTokenFlag(fs *pflag.FlagSet) {
+	opaquetoken.AddFlag(fs)
 }
 
 // AddParameterFlag adds the '--parameter' flag to the given set of command line flags.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	ClientID     string   `json:"client_id,omitempty" doc:"OpenID client identifier."`
 	ClientSecret string   `json:"client_secret,omitempty" doc:"OpenID client secret."`
 	Insecure     bool     `json:"insecure,omitempty" doc:"Enables insecure communication with the server. This disables verification of TLS certificates and host names."`
+	OpaqueToken  bool     `json:"opaque_token,omitempty" doc:"Indicates that the access token is opaque (non-JWT) and should be sent as-is without SDK token management."`
 	Password     string   `json:"password,omitempty" doc:"User password."`
 	RefreshToken string   `json:"refresh_token,omitempty" doc:"Offline or refresh token."`
 	Scopes       []string `json:"scopes,omitempty" doc:"OpenID scope. If this option is used it will replace completely the default scopes. Can be repeated multiple times to specify multiple scopes."`
@@ -183,7 +184,7 @@ func Location() (path string, err error) {
 
 // Armed checks if the configuration contains either credentials or tokens that haven't expired, so
 // that it can be used to perform authenticated requests.
-func (c *Config) Armed() (armed bool, reason string, err error) {
+func (c *Config) Armed(opaqueMode bool) (armed bool, reason string, err error) {
 	// Check URLs:
 	haveURL := c.URL != ""
 	haveTokenURL := c.TokenURL != ""
@@ -198,17 +199,21 @@ func (c *Config) Armed() (armed bool, reason string, err error) {
 	haveAccess := c.AccessToken != ""
 	accessUsable := false
 	if haveAccess {
-		accessUsable, err = tokenUsable(c.AccessToken, 5*time.Second)
-		if err != nil {
-			return
+		if opaqueMode {
+			accessUsable = true
+		} else {
+			accessUsable, err = tokenUsable(c.AccessToken, 5*time.Second)
+			if err != nil {
+				return
+			}
 		}
 	}
 	haveRefresh := c.RefreshToken != ""
 	refreshUsable := false
 	if haveRefresh {
-		if IsEncryptedToken(c.RefreshToken) {
-			// We have no way of knowing an encrypted token expiration, so
-			// we assume it's valid and let the access token request fail.
+		if opaqueMode {
+			refreshUsable = false
+		} else if IsEncryptedToken(c.RefreshToken) {
 			refreshUsable = true
 		} else {
 			refreshUsable, err = tokenUsable(c.RefreshToken, 10*time.Second)
@@ -254,6 +259,7 @@ func (c *Config) Disarm() {
 	c.ClientID = ""
 	c.ClientSecret = ""
 	c.Insecure = false
+	c.OpaqueToken = false
 	c.Password = ""
 	c.RefreshToken = ""
 	c.Scopes = nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Armed", func() {
 			URL:      "http://my-server.example.com",
 			TokenURL: "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeTrue())
 		Expect(reason).To(BeEmpty())
@@ -50,7 +50,7 @@ var _ = Describe("Armed", func() {
 			URL:          "http://my-server.example.com",
 			TokenURL:     "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeTrue())
 		Expect(reason).To(BeEmpty())
@@ -62,7 +62,7 @@ var _ = Describe("Armed", func() {
 			URL:         "http://my-server.example.com",
 			TokenURL:    "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeTrue())
 		Expect(reason).To(BeEmpty())
@@ -74,7 +74,7 @@ var _ = Describe("Armed", func() {
 			URL:         "http://my-server.example.com",
 			TokenURL:    "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeTrue())
 		Expect(reason).To(BeEmpty())
@@ -87,7 +87,7 @@ var _ = Describe("Armed", func() {
 			URL:          "http://my-server.example.com",
 			TokenURL:     "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeTrue())
 		Expect(reason).To(BeEmpty())
@@ -100,7 +100,7 @@ var _ = Describe("Armed", func() {
 			URL:          "http://my-server.example.com",
 			TokenURL:     "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeTrue())
 		Expect(reason).To(BeEmpty())
@@ -112,7 +112,7 @@ var _ = Describe("Armed", func() {
 			URL:         "http://my-server.example.com",
 			TokenURL:    "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeFalse())
 		Expect(reason).To(Equal("access token is expired"))
@@ -124,7 +124,7 @@ var _ = Describe("Armed", func() {
 			URL:          "http://my-server.example.com",
 			TokenURL:     "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeFalse())
 		Expect(reason).To(Equal("refresh token is expired"))
@@ -137,7 +137,7 @@ var _ = Describe("Armed", func() {
 			URL:          "http://my-server.example.com",
 			TokenURL:     "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeFalse())
 		Expect(reason).To(Equal("access and refresh tokens are expired"))
@@ -149,7 +149,7 @@ var _ = Describe("Armed", func() {
 			URL:      "http://my-server.example.com",
 			TokenURL: "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeFalse())
 		Expect(reason).To(Equal("credentials aren't set"))
@@ -161,7 +161,7 @@ var _ = Describe("Armed", func() {
 			URL:      "http://my-server.example.com",
 			TokenURL: "http://my-sso.example.com",
 		}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeFalse())
 		Expect(reason).To(Equal("credentials aren't set"))
@@ -169,9 +169,71 @@ var _ = Describe("Armed", func() {
 
 	It("Isn't armed if empty", func() {
 		config := &Config{}
-		armed, reason, err := config.Armed()
+		armed, reason, err := config.Armed(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(armed).To(BeFalse())
 		Expect(reason).To(Equal("credentials aren't set"))
+	})
+
+	It("Is armed if OpaqueToken is set with an opaque access token", func() {
+		config := &Config{
+			AccessToken: "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729",
+			OpaqueToken: true,
+			URL:         "http://my-server.example.com",
+			TokenURL:    "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed(true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+
+	It("Is armed in opaque mode even with a non-JWT refresh token", func() {
+		config := &Config{
+			AccessToken:  "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729",
+			RefreshToken: "GONDOLIN_REFRESH_abc123def456",
+			OpaqueToken:  true,
+			URL:          "http://my-server.example.com",
+			TokenURL:     "http://my-sso.example.com",
+		}
+		armed, reason, err := config.Armed(true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(armed).To(BeTrue())
+		Expect(reason).To(BeEmpty())
+	})
+
+	It("Is not armed if OpaqueToken is false and access token is not a JWT", func() {
+		config := &Config{
+			AccessToken: "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729",
+			OpaqueToken: false,
+			URL:         "http://my-server.example.com",
+			TokenURL:    "http://my-sso.example.com",
+		}
+		armed, _, err := config.Armed(false)
+		Expect(err).To(HaveOccurred())
+		Expect(armed).To(BeFalse())
+	})
+})
+
+var _ = Describe("IsJWTToken", func() {
+	It("Returns true for a standard 3-segment JWT", func() {
+		token := MakeTokenString("Bearer", 15*time.Minute)
+		Expect(IsJWTToken(token)).To(BeTrue())
+	})
+
+	It("Returns false for an opaque token without dots", func() {
+		Expect(IsJWTToken("GONDOLIN_SECRET_d5bfa746c20ab8140fae5729")).To(BeFalse())
+	})
+
+	It("Returns false for a token with one dot", func() {
+		Expect(IsJWTToken("some.token")).To(BeFalse())
+	})
+
+	It("Returns false for a 5-segment JWE token", func() {
+		Expect(IsJWTToken("a.b.c.d.e")).To(BeFalse())
+	})
+
+	It("Returns false for an empty string", func() {
+		Expect(IsJWTToken("")).To(BeFalse())
 	})
 })

--- a/pkg/config/token.go
+++ b/pkg/config/token.go
@@ -53,6 +53,11 @@ func IsEncryptedToken(textToken string) bool {
 	return false
 }
 
+func IsJWTToken(textToken string) bool {
+	parts := strings.Split(textToken, ".")
+	return len(parts) == 3
+}
+
 func ParseToken(textToken string) (token *jwt.Token, err error) {
 	parser := new(jwt.Parser)
 	token, _, err = parser.ParseUnverified(textToken, jwt.MapClaims{})

--- a/pkg/ocm/connection-builder/connection.go
+++ b/pkg/ocm/connection-builder/connection.go
@@ -15,6 +15,7 @@ package connection
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/golang/glog"
 	"github.com/openshift-online/ocm-common/pkg/deprecation"
@@ -24,6 +25,7 @@ import (
 	"github.com/openshift-online/ocm-cli/pkg/config"
 	"github.com/openshift-online/ocm-cli/pkg/debug"
 	"github.com/openshift-online/ocm-cli/pkg/info"
+	"github.com/openshift-online/ocm-cli/pkg/opaquetoken"
 )
 
 // ConnectionBuilder contains the information and logic needed to build a connection to OCM. Don't
@@ -89,8 +91,10 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 		}
 	}
 
+	opaqueMode := b.cfg.OpaqueToken || opaquetoken.Enabled()
+
 	// Check that the configuration has credentials or tokens that haven't have expired:
-	armed, reason, err := b.cfg.Armed()
+	armed, reason, err := b.cfg.Armed(opaqueMode)
 	if err != nil {
 		return
 	}
@@ -99,7 +103,7 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 		return
 	}
 
-	builder := b.initConnectionBuilderFromConfig()
+	builder := b.initConnectionBuilderFromConfig(opaqueMode)
 
 	logger, err := b.getLogger()
 	if err != nil {
@@ -118,8 +122,17 @@ func (b *ConnectionBuilder) Build() (result *sdk.Connection, err error) {
 	return builder.Build()
 }
 
-func (b *ConnectionBuilder) initConnectionBuilderFromConfig() *sdk.ConnectionBuilder {
-	builder := sdk.NewConnectionBuilder()
+func (b *ConnectionBuilder) initConnectionBuilderFromConfig(opaqueMode bool) *sdk.ConnectionBuilder {
+	var builder *sdk.ConnectionBuilder
+	if opaqueMode {
+		builder = sdk.NewUnauthenticatedConnectionBuilder()
+		token := b.cfg.AccessToken
+		builder.TransportWrapper(func(wrapped http.RoundTripper) http.RoundTripper {
+			return &opaqueTokenTransport{next: wrapped, token: token}
+		})
+	} else {
+		builder = sdk.NewConnectionBuilder()
+	}
 
 	// Add deprecation transport wrapper to automatically handle deprecation headers
 	builder.TransportWrapper(deprecation.NewTransportWrapper())
@@ -141,19 +154,34 @@ func (b *ConnectionBuilder) initConnectionBuilderFromConfig() *sdk.ConnectionBui
 	if b.cfg.URL != "" {
 		builder.URL(b.cfg.URL)
 	}
-	tokens := make([]string, 0, 2)
-	if b.cfg.AccessToken != "" {
-		tokens = append(tokens, b.cfg.AccessToken)
-	}
-	if b.cfg.RefreshToken != "" {
-		tokens = append(tokens, b.cfg.RefreshToken)
-	}
-	if len(tokens) > 0 {
-		builder.Tokens(tokens...)
+	if !opaqueMode {
+		tokens := make([]string, 0, 2)
+		if b.cfg.AccessToken != "" {
+			tokens = append(tokens, b.cfg.AccessToken)
+		}
+		if b.cfg.RefreshToken != "" {
+			tokens = append(tokens, b.cfg.RefreshToken)
+		}
+		if len(tokens) > 0 {
+			builder.Tokens(tokens...)
+		}
 	}
 	builder.Insecure(b.cfg.Insecure)
 
 	return builder
+}
+
+// opaqueTokenTransport injects an Authorization header for opaque (non-JWT)
+// tokens, bypassing the SDK's built-in token management.
+type opaqueTokenTransport struct {
+	next  http.RoundTripper
+	token string
+}
+
+func (t *opaqueTokenTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	clone := request.Clone(request.Context())
+	clone.Header.Set("Authorization", "Bearer "+t.token)
+	return t.next.RoundTrip(clone)
 }
 
 // Returns the configured logger or a default if there is none configured

--- a/pkg/opaquetoken/flag.go
+++ b/pkg/opaquetoken/flag.go
@@ -1,0 +1,48 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opaquetoken
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/spf13/pflag"
+
+	"github.com/openshift-online/ocm-cli/pkg/properties"
+)
+
+// AddFlag adds the --opaque-token flag to the given set of command line flags.
+func AddFlag(flags *pflag.FlagSet) {
+	flags.BoolVar(
+		&enabled,
+		"opaque-token",
+		false,
+		"Treat the access token as an opaque (non-JWT) token. Can also be "+
+			"enabled by setting the OCM_OPAQUE_TOKEN environment variable.",
+	)
+}
+
+// Enabled returns true if opaque token mode is enabled via the flag or environment variable.
+func Enabled() bool {
+	if enabled {
+		return true
+	}
+	val, err := strconv.ParseBool(os.Getenv(properties.OpaqueTokenEnvKey))
+	return err == nil && val
+}
+
+var enabled bool

--- a/pkg/opaquetoken/flag_test.go
+++ b/pkg/opaquetoken/flag_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opaquetoken
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/gomega"    // nolint
+	"github.com/spf13/pflag"
+
+	"github.com/openshift-online/ocm-cli/pkg/properties"
+)
+
+var _ = Describe("Enabled", func() {
+	BeforeEach(func() {
+		enabled = false
+		os.Unsetenv(properties.OpaqueTokenEnvKey)
+	})
+
+	AfterEach(func() {
+		enabled = false
+		os.Unsetenv(properties.OpaqueTokenEnvKey)
+	})
+
+	It("Returns false by default", func() {
+		Expect(Enabled()).To(BeFalse())
+	})
+
+	It("Returns true when env var is 'true'", func() {
+		os.Setenv(properties.OpaqueTokenEnvKey, "true")
+		Expect(Enabled()).To(BeTrue())
+	})
+
+	It("Returns true when env var is '1'", func() {
+		os.Setenv(properties.OpaqueTokenEnvKey, "1")
+		Expect(Enabled()).To(BeTrue())
+	})
+
+	It("Returns false when env var is 'false'", func() {
+		os.Setenv(properties.OpaqueTokenEnvKey, "false")
+		Expect(Enabled()).To(BeFalse())
+	})
+
+	It("Returns false when env var is invalid", func() {
+		os.Setenv(properties.OpaqueTokenEnvKey, "notabool")
+		Expect(Enabled()).To(BeFalse())
+	})
+
+	It("Returns true when flag is set", func() {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		AddFlag(fs)
+		err := fs.Parse([]string{"--opaque-token"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(Enabled()).To(BeTrue())
+	})
+
+	It("Returns true when flag is set even if env var is false", func() {
+		os.Setenv(properties.OpaqueTokenEnvKey, "false")
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		AddFlag(fs)
+		err := fs.Parse([]string{"--opaque-token"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(Enabled()).To(BeTrue())
+	})
+})

--- a/pkg/opaquetoken/main_test.go
+++ b/pkg/opaquetoken/main_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Red Hat, Inc.
+Copyright (c) 2025 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,10 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package properties
+package opaquetoken
 
-const (
-	KeyringEnvKey     = "OCM_KEYRING"
-	OpaqueTokenEnvKey = "OCM_OPAQUE_TOKEN" // #nosec G101
-	URLEnvKey         = "OCM_URL"
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" // nolint
+	. "github.com/onsi/gomega"    // nolint
 )
+
+func TestOpaqueToken(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OpaqueToken")
+}

--- a/tests/get_test.go
+++ b/tests/get_test.go
@@ -36,6 +36,52 @@ var _ = Describe("Get", func() {
 		ctx = context.Background()
 	})
 
+	When("Using opaque token", func() {
+		var apiServer *Server
+
+		BeforeEach(func() {
+			apiServer = MakeTCPServer()
+		})
+
+		AfterEach(func() {
+			apiServer.Close()
+		})
+
+		It("Preserves the opaque token in the config after a GET request", func() {
+			opaqueToken := "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729"
+
+			// Prepare the server:
+			apiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{ "my_field": "my_value" }`,
+				),
+			)
+
+			// Run the command with opaque token config:
+			result := NewCommand().
+				ConfigString(
+					`{
+						"access_token": "{{ .accessToken }}",
+						"opaque_token": true,
+						"url": "{{ .url }}",
+						"token_url": "http://my-sso.example.com"
+					}`,
+					"accessToken", opaqueToken,
+					"url", apiServer.URL(),
+				).
+				Args("get", "/api/my_service/v1/my_object").
+				Run(ctx)
+
+			Expect(result.ExitCode()).To(BeZero())
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(result.OutString()).To(MatchJSON(`{ "my_field": "my_value" }`))
+
+			// Verify the opaque token is preserved in the config:
+			Expect(result.ConfigString()).To(ContainSubstring(opaqueToken))
+		})
+	})
+
 	When("Config file doesn't exist", func() {
 		It("Fails", func() {
 			getResult := NewCommand().

--- a/tests/login_test.go
+++ b/tests/login_test.go
@@ -112,6 +112,38 @@ var _ = Describe("Login", func() {
 		})
 	})
 
+	When("Using opaque token", func() {
+		It("Fails with --opaque-token flag", func() {
+			opaqueToken := "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729"
+
+			result := NewCommand().
+				Args(
+					"login",
+					"--opaque-token",
+					"--token", opaqueToken,
+					"--token-url", ssoServer.URL(),
+				).
+				Run(ctx)
+
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("not used with the login command"))
+		})
+
+		It("Fails with OCM_OPAQUE_TOKEN env var", func() {
+			result := NewCommand().
+				Env("OCM_OPAQUE_TOKEN", "true").
+				Args(
+					"login",
+					"--token", "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729",
+					"--token-url", ssoServer.URL(),
+				).
+				Run(ctx)
+
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("not used with the login command"))
+		})
+	})
+
 	When("Using client credentials grant", func() {
 		It("Creates the configuration file", func() {
 			// Create the token:

--- a/tests/logout_test.go
+++ b/tests/logout_test.go
@@ -112,6 +112,18 @@ var _ = Describe("Logout", func() {
 		Expect(result.ConfigString()).To(MatchJSON(`{}`))
 	})
 
+	It("Removes opaque_token flag from configuration file", func() {
+		result := NewCommand().
+			ConfigString(`{
+				"access_token": "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729",
+				"opaque_token": true
+			}`).
+			Args("logout").
+			Run(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+		Expect(result.ConfigString()).To(MatchJSON(`{}`))
+	})
+
 	It("Doesn't remove settings not related to authentication", func() {
 		result := NewCommand().
 			ConfigString(`{

--- a/tests/token_test.go
+++ b/tests/token_test.go
@@ -73,6 +73,77 @@ var _ = Describe("Token", func() {
 		})
 	})
 
+	When("Logged in with opaque token", func() {
+		var opaqueToken string
+
+		BeforeEach(func() {
+			opaqueToken = "GONDOLIN_SECRET_d5bfa746c20ab8140fae5729"
+			cmd = NewCommand().
+				ConfigString(
+					`{
+						"access_token": "{{ .accessToken }}",
+						"opaque_token": true,
+						"url": "http://my-server.example.com",
+						"token_url": "http://my-sso.example.com"
+					}`,
+					"accessToken", opaqueToken,
+				).
+				Arg("token")
+		})
+
+		It("Displays the opaque access token", func() {
+			result := cmd.Run(ctx)
+			Expect(result.OutString()).To(Equal(opaqueToken + "\n"))
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(result.ExitCode()).To(BeZero())
+		})
+
+		It("Displays the opaque refresh token", func() {
+			refreshToken := "GONDOLIN_REFRESH_abc123"
+			cmd = NewCommand().
+				ConfigString(
+					`{
+						"access_token": "{{ .accessToken }}",
+						"opaque_token": true,
+						"refresh_token": "{{ .refreshToken }}",
+						"url": "http://my-server.example.com",
+						"token_url": "http://my-sso.example.com"
+					}`,
+					"accessToken", opaqueToken,
+					"refreshToken", refreshToken,
+				).
+				Args("token", "--refresh")
+			result := cmd.Run(ctx)
+			Expect(result.OutString()).To(Equal(refreshToken + "\n"))
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(result.ExitCode()).To(BeZero())
+		})
+
+		It("Rejects --header for opaque tokens", func() {
+			result := cmd.Arg("--header").Run(ctx)
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("not a JWT"))
+		})
+
+		It("Rejects --payload for opaque tokens", func() {
+			result := cmd.Arg("--payload").Run(ctx)
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("not a JWT"))
+		})
+
+		It("Rejects --signature for opaque tokens", func() {
+			result := cmd.Arg("--signature").Run(ctx)
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("not a JWT"))
+		})
+
+		It("Rejects --generate for opaque tokens", func() {
+			result := cmd.Arg("--generate").Run(ctx)
+			Expect(result.ExitCode()).ToNot(BeZero())
+			Expect(result.ErrString()).To(ContainSubstring("opaque tokens"))
+		})
+	})
+
 	When("Not logged in", func() {
 		BeforeEach(func() {
 			cmd = NewCommand().Arg("token")


### PR DESCRIPTION
## Summary

- Add `--opaque-token` global flag and `OCM_OPAQUE_TOKEN` environment variable for environments that use opaque (non-JWT) tokens
- Use unauthenticated SDK connection with a custom HTTP transport wrapper that injects the Bearer token directly, bypassing SDK token management
- Skip token refresh in API commands (GET/POST/PATCH/DELETE) when opaque mode is active
- Add `opaque_token` to `ocm config get` and `ocm config set` commands
- Reject `--opaque-token` during `ocm login` with a guidance message showing the correct workflow
- Add README documentation covering per-invocation and persistent usage modes
- Supersedes #1115 

## Test plan

- [x] All existing tests pass (`make test` — 232 specs, 0 failures)
- [x] New unit tests for `opaquetoken.Enabled()` flag and env var handling
- [x] New unit tests for `config.IsJWTToken()` helper
- [x] New integration tests for opaque token preservation during GET requests
- [x] New integration tests for login rejection with `--opaque-token`
- [x] New integration tests for logout clearing `opaque_token` config
- [x] New integration tests for `ocm token` with opaque tokens (display, `--generate` rejection, JWT-only option rejection)
- [x] Manual testing with an actual opaque token against a sandbox environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)