### PR TITLE
ROSAENG-13680 | feat: add --fail-fast flag to wif-config operations

### DIFF
--- a/cmd/ocm/gcp/create-wif-config.go
+++ b/cmd/ocm/gcp/create-wif-config.go
@@ -88,6 +88,8 @@ wif-config resource within OCM to represent those resources.`,
 		versionFlagDescription,
 	)
 
+	addWifConfigFailFastFlag(createWifConfigCmd)
+
 	return createWifConfigCmd
 }
 
@@ -236,6 +238,7 @@ func createWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 	gcpClientWifConfigShim := NewGcpClientWifConfigShim(GcpClientWifConfigShimSpec{
 		GcpClient: gcpClient,
 		WifConfig: wifConfig,
+		FailFast:  wifConfigOptions.FailFast,
 	})
 
 	if err := gcpClientWifConfigShim.GrantSupportAccess(ctx, log); err != nil {
@@ -258,6 +261,11 @@ func createWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 		return fmt.Errorf("To clean up, run the following command: ocm gcp delete wif-config %s", wifConfig.ID())
 	}
 
+	retryTimeout := IamApiRetrySeconds
+	if wifConfigOptions.FailFast {
+		retryTimeout = IamApiFailFastRetrySeconds
+	}
+
 	//The IAM API is eventually consistent. If the user created the service
 	//accounts needed for cluster deployment within too brief a period, then
 	//our backend will not yet have access to it. To avoid confusing error
@@ -269,7 +277,7 @@ func createWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 			return true, err
 		}
 		return false, nil
-	}, IamApiRetrySeconds, log); err != nil {
+	}, retryTimeout, log); err != nil {
 		return fmt.Errorf("Timed out verifying wif-config resources\n"+
 			"Please run 'ocm gcp update wif-config %s' to repair potential misconfigurations "+
 			"and to complete the wif-config creation process", wifConfig.ID())

--- a/cmd/ocm/gcp/delete-wif-config.go
+++ b/cmd/ocm/gcp/delete-wif-config.go
@@ -58,6 +58,8 @@ GCP resources represented by the wif-config.
 		targetDirFlagDescription,
 	)
 
+	addWifConfigFailFastFlag(deleteWifConfigCmd)
+
 	return deleteWifConfigCmd
 }
 
@@ -120,6 +122,7 @@ func deleteWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 	shim := NewGcpClientWifConfigShim(GcpClientWifConfigShimSpec{
 		WifConfig: wifConfig,
 		GcpClient: gcpClient,
+		FailFast:  wifConfigOptions.FailFast,
 	})
 	log := log.Default()
 

--- a/cmd/ocm/gcp/gcp-client-shim.go
+++ b/cmd/ocm/gcp/gcp-client-shim.go
@@ -24,6 +24,9 @@ import (
 const (
 	// The time in seconds in which IAM inconsistencies may occur.
 	IamApiRetrySeconds = 600
+
+	// Fast-fail timeout for expected failures
+	IamApiFailFastRetrySeconds = 30
 )
 
 const (
@@ -48,18 +51,29 @@ type GcpClientWifConfigShim interface {
 type shim struct {
 	wifConfig *cmv1.WifConfig
 	gcpClient gcp.GcpClient
+	failFast  bool
 }
 
 type GcpClientWifConfigShimSpec struct {
 	WifConfig *cmv1.WifConfig
 	GcpClient gcp.GcpClient
+	FailFast  bool
 }
 
 func NewGcpClientWifConfigShim(spec GcpClientWifConfigShimSpec) GcpClientWifConfigShim {
 	return &shim{
 		wifConfig: spec.WifConfig,
 		gcpClient: spec.GcpClient,
+		failFast:  spec.FailFast,
 	}
+}
+
+// getRetryTimeout returns the appropriate timeout based on fail-fast setting
+func (c *shim) getRetryTimeout() int {
+	if c.failFast {
+		return IamApiFailFastRetrySeconds
+	}
+	return IamApiRetrySeconds
 }
 
 func (c *shim) CreateServiceAccounts(
@@ -70,12 +84,14 @@ func (c *shim) CreateServiceAccounts(
 		sa      *adminpb.ServiceAccount
 		lastErr error
 	)
+	retryTimeout := c.getRetryTimeout()
+
 	for _, serviceAccount := range c.wifConfig.Gcp().ServiceAccounts() {
 		if err := utils.RetryWithBackoffandTimeout(func() (bool, error) {
 			log.Printf("Ensuring service account '%s' exists...", serviceAccount.ServiceAccountId())
 			sa, lastErr = c.createServiceAccount(ctx, log, serviceAccount)
 			return lastErr != nil, lastErr
-		}, IamApiRetrySeconds, log); err != nil {
+		}, retryTimeout, log); err != nil {
 			return lastErr
 		}
 
@@ -88,7 +104,7 @@ func (c *shim) CreateServiceAccounts(
 					serviceAccount,
 				)
 				return lastErr != nil, lastErr
-			}, IamApiRetrySeconds, log); err != nil {
+			}, retryTimeout, log); err != nil {
 				return lastErr
 			}
 			log.Printf("IAM service account '%s' has been enabled", serviceAccount.ServiceAccountId())
@@ -98,7 +114,7 @@ func (c *shim) CreateServiceAccounts(
 			log.Printf("Ensuring roles exist for service account '%s'...", serviceAccount.ServiceAccountId())
 			lastErr = c.createOrUpdateRoles(ctx, log, serviceAccount.Roles())
 			return lastErr != nil, lastErr
-		}, IamApiRetrySeconds, log); err != nil {
+		}, retryTimeout, log); err != nil {
 			return lastErr
 		}
 
@@ -106,7 +122,7 @@ func (c *shim) CreateServiceAccounts(
 			log.Printf("Ensuring role bindings for service account '%s'...", serviceAccount.ServiceAccountId())
 			lastErr = c.bindRolesToServiceAccount(ctx, log, serviceAccount)
 			return lastErr != nil, lastErr
-		}, IamApiRetrySeconds, log); err != nil {
+		}, retryTimeout, log); err != nil {
 			return lastErr
 		}
 
@@ -114,7 +130,7 @@ func (c *shim) CreateServiceAccounts(
 			log.Printf("Ensuring access to service account '%s'...", serviceAccount.ServiceAccountId())
 			lastErr = c.grantAccessToServiceAccount(ctx, log, serviceAccount)
 			return lastErr != nil, lastErr
-		}, IamApiRetrySeconds, log); err != nil {
+		}, retryTimeout, log); err != nil {
 			return lastErr
 		}
 	}
@@ -126,7 +142,7 @@ func (c *shim) CreateServiceAccounts(
 			log.Printf("Ensuring policy bindings for service account '%s'...", serviceAccount.ServiceAccountId())
 			lastErr = c.bindPoliciesToServiceAccount(ctx, log, serviceAccount)
 			return lastErr != nil, lastErr
-		}, IamApiRetrySeconds, log); err != nil {
+		}, retryTimeout, log); err != nil {
 			return lastErr
 		}
 	}
@@ -142,7 +158,7 @@ func (c *shim) CreateWorkloadIdentityPool(
 		log.Print("Ensuring workload identity pool exists...")
 		lastErr = c.createWorkloadIdentityPool(ctx, log)
 		return lastErr != nil, lastErr
-	}, IamApiRetrySeconds, log); err != nil {
+	}, c.getRetryTimeout(), log); err != nil {
 		return lastErr
 	}
 	return nil
@@ -157,7 +173,7 @@ func (c *shim) CreateWorkloadIdentityProvider(
 		log.Print("Ensuring workload identity pool OIDC provider exists...")
 		lastErr = c.createWorkloadIdentityProvider(ctx, log)
 		return lastErr != nil, lastErr
-	}, IamApiRetrySeconds, log); err != nil {
+	}, c.getRetryTimeout(), log); err != nil {
 		return lastErr
 	}
 	return nil
@@ -172,7 +188,7 @@ func (c *shim) GrantSupportAccess(
 		log.Print("Ensuring Red Hat support has access to project...")
 		lastErr = c.grantSupportAccess(ctx, log)
 		return lastErr != nil, lastErr
-	}, IamApiRetrySeconds, log); err != nil {
+	}, c.getRetryTimeout(), log); err != nil {
 		return lastErr
 	}
 	return nil
@@ -1124,7 +1140,7 @@ func (c *shim) DeleteServiceAccounts(
 			log.Printf("Deleting service account '%s'...", serviceAccountID)
 			lastErr = c.gcpClient.DeleteServiceAccount(ctx, serviceAccountID, projectId, true)
 			return lastErr != nil, lastErr
-		}, IamApiRetrySeconds, log); err != nil {
+		}, c.getRetryTimeout(), log); err != nil {
 			return errors.Wrapf(lastErr, "Failed to delete service account '%s'", serviceAccountID)
 		}
 	}
@@ -1140,7 +1156,7 @@ func (c *shim) DeleteWorkloadIdentityPool(
 		log.Print("Deleting workload identity pool...")
 		lastErr = c.deleteWorkloadIdentityPool(ctx, log)
 		return lastErr != nil, lastErr
-	}, IamApiRetrySeconds, log); err != nil {
+	}, c.getRetryTimeout(), log); err != nil {
 		return lastErr
 	}
 	return nil
@@ -1175,6 +1191,7 @@ func (c *shim) UnbindServiceAccounts(
 	log *log.Logger,
 ) error {
 	var lastErr error
+	retryTimeout := c.getRetryTimeout()
 
 	log.Print("Unbinding service accounts from project IAM policy...")
 	for _, serviceAccount := range c.wifConfig.Gcp().ServiceAccounts() {
@@ -1187,7 +1204,7 @@ func (c *shim) UnbindServiceAccounts(
 				serviceAccount.Roles(),
 			)
 			return lastErr != nil, lastErr
-		}, IamApiRetrySeconds, log); err != nil {
+		}, retryTimeout, log); err != nil {
 			return errors.Wrapf(lastErr, "Failed to unbind service account '%s'", serviceAccount.ServiceAccountId())
 		}
 
@@ -1199,7 +1216,7 @@ func (c *shim) UnbindServiceAccounts(
 				serviceAccount.Roles(),
 			)
 			return lastErr != nil, lastErr
-		}, IamApiRetrySeconds, log); err != nil {
+		}, retryTimeout, log); err != nil {
 			return errors.Wrapf(lastErr, "Failed to unbind service account '%s'", serviceAccount.ServiceAccountId())
 		}
 	}

--- a/cmd/ocm/gcp/gcp.go
+++ b/cmd/ocm/gcp/gcp.go
@@ -16,6 +16,20 @@ type options struct {
 	TargetDir                string
 	WorkloadIdentityPool     string
 	WorkloadIdentityProvider string
+	FailFast                 bool
+}
+
+// wifConfigOptions holds options shared across all wif-config commands
+var wifConfigOptions options
+
+// addWifConfigFailFastFlag adds the --fail-fast flag to wif-config commands
+func addWifConfigFailFastFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(
+		&wifConfigOptions.FailFast,
+		"fail-fast",
+		false,
+		"Use 30-second retry timeout instead of 10-minute timeout (useful for expected failures in validation tests)",
+	)
 }
 
 // NewGcpCmd implements the "gcp" subcommand for the credentials provisioning

--- a/cmd/ocm/gcp/update-wif-config.go
+++ b/cmd/ocm/gcp/update-wif-config.go
@@ -64,6 +64,8 @@ the wif-config metadata and the GCP resources it represents.`,
 		federatedProjectFlagDescription,
 	)
 
+	addWifConfigFailFastFlag(updateWifConfigCmd)
+
 	return updateWifConfigCmd
 }
 
@@ -158,6 +160,7 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 	gcpClientWifConfigShim := NewGcpClientWifConfigShim(GcpClientWifConfigShimSpec{
 		GcpClient: gcpClient,
 		WifConfig: wifConfig,
+		FailFast:  wifConfigOptions.FailFast,
 	})
 
 	log.Println("Updating support access...")
@@ -180,6 +183,11 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 		return fmt.Errorf("Failed to update IAM service accounts: %s", err)
 	}
 
+	retryTimeout := IamApiRetrySeconds
+	if wifConfigOptions.FailFast {
+		retryTimeout = IamApiFailFastRetrySeconds
+	}
+
 	//The IAM API is eventually consistent. If the user created the service
 	//accounts needed for cluster deployment within too brief a period, then
 	//our backend will not yet have access to it. To avoid confusing error
@@ -191,7 +199,7 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 			return true, err
 		}
 		return false, nil
-	}, IamApiRetrySeconds, log); err != nil {
+	}, retryTimeout, log); err != nil {
 		return fmt.Errorf("Timed out verifying wif-config resources\n"+
 			"Please try 'ocm gcp update wif-config %s' again in a few minutes, "+
 			"or contact Red Hat support.", wifConfig.ID())


### PR DESCRIPTION
## Description

Universal flag for all wif-config commands to reduce retry timeout from 10 minutes to 30 seconds when failures are expected, improving test efficiency.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

```
ocm gcp update wif-config --help | grep "--fail-fast"
      --fail-fast                  Return immediately on first error instead of retrying (useful for validation tests)

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ocm gcp delete wif-config 2p7dkterflc0qleeecnk95gu5ba6pd43 --fail-fast
2026/06/10 17:51:08 Unbinding service accounts from project IAM policy...
2026/06/10 17:51:08 Unbinding service account 'cloud-network-config-ctrl-pd43'...
2026/06/10 17:51:09 Trying again in 1 seconds...
2026/06/10 17:51:10 Unbinding service account 'cloud-network-config-ctrl-pd43'...
2026/06/10 17:51:11 Trying again in 2 seconds...
2026/06/10 17:51:13 Unbinding service account 'cloud-network-config-ctrl-pd43'...
2026/06/10 17:51:13 Trying again in 4 seconds...
2026/06/10 17:51:17 Unbinding service account 'cloud-network-config-ctrl-pd43'...
2026/06/10 17:51:17 Trying again in 8 seconds...
2026/06/10 17:51:25 Unbinding service account 'cloud-network-config-ctrl-pd43'...
2026/06/10 17:51:25 Trying again in 16 seconds...
Error: Failed to unbind service account 'cloud-network-config-ctrl-pd43': Failed to unbind roles from principal serviceAccount:cloud-network-config-ctrl-pd43@testprojectID.iam.gserviceaccount.com: Failed to fetch policy for project: googleapi: Error 400: Request contains an invalid argument., badRequest

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ocm gcp update wif-config 2p7dkterflc0qleeecnk95gu5ba6pd43 --fail-fast
2026/06/10 17:52:15 Updating support access...
2026/06/10 17:52:15 Ensuring Red Hat support has access to project...
2026/06/10 17:52:16 Trying again in 1 seconds...
2026/06/10 17:52:17 Ensuring Red Hat support has access to project...
2026/06/10 17:52:17 Trying again in 2 seconds...
2026/06/10 17:52:19 Ensuring Red Hat support has access to project...
2026/06/10 17:52:19 Trying again in 4 seconds...
2026/06/10 17:52:24 Ensuring Red Hat support has access to project...
2026/06/10 17:52:24 Trying again in 8 seconds...
2026/06/10 17:52:32 Ensuring Red Hat support has access to project...
2026/06/10 17:52:33 Trying again in 16 seconds...
Error: Failed to grant support access to project: Failed to check if role exists: rpc error: code = InvalidArgument desc = The role name must be in the form "roles/{role}", "organizations/{organization_id}/roles/{role}", or "projects/{project_id}/roles/{role}".

mipereir@mipereir-thinkpadp1gen4i:~/myprojects/ocm-cli$ ocm gcp create wif-config --name mipereir-fail-fast --project projectID --fail-fast
...
2026/06/10 17:56:47 Ensuring policy bindings for service account 'cloud-credential-op-gcp-og75'...
2026/06/10 17:56:47 Ensuring policy bindings for service account 'cloud-network-config-ctrl-og75'...
2026/06/10 17:56:47 Verifying wif-config '2qro2iukhlgsk1dd4qm0g5c1qhsnog75'...
2026/06/10 17:56:48 Trying again in 1 seconds...
2026/06/10 17:56:49 Verifying wif-config '2qro2iukhlgsk1dd4qm0g5c1qhsnog75'...
2026/06/10 17:56:50 Trying again in 2 seconds...
2026/06/10 17:56:52 Verifying wif-config '2qro2iukhlgsk1dd4qm0g5c1qhsnog75'...
2026/06/10 17:56:53 Trying again in 4 seconds...
2026/06/10 17:56:58 Verifying wif-config '2qro2iukhlgsk1dd4qm0g5c1qhsnog75'...
2026/06/10 17:56:59 Trying again in 8 seconds...
2026/06/10 17:57:07 Verifying wif-config '2qro2iukhlgsk1dd4qm0g5c1qhsnog75'...
2026/06/10 17:57:07 Trying again in 16 seconds...
Error: Timed out verifying wif-config resources
Please run 'ocm gcp update wif-config 2qro2iukhlgsk1dd4qm0g5c1qhsnog75' to repair potential misconfigurations and to complete the wif-config creation process
```

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [x] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
