### PR TITLE
ROSAENG-59254 | fix: handle WifConfig retrieval errors gracefully

### DIFF
--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -28,7 +28,6 @@ import (
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	slv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -171,14 +170,6 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 		)
 	}
 
-	var wifConfig *cmv1.WifConfig
-	if cluster.GCP().Authentication().Id() != "" {
-		wifConfig, err = findWifConfig(connection, cluster)
-		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve wif-config associated with the cluster")
-		}
-	}
-
 	// Print short cluster description:
 	fmt.Printf("\n"+
 		"ID:				%s\n"+
@@ -288,10 +279,7 @@ func PrintClusterDescription(connection *sdk.Connection, cluster *cmv1.Cluster) 
 			fmt.Printf("Authentication Type:		%s\n",
 				getAuthenticationDisplayName(cluster.GCP().Authentication().Kind()))
 		}
-		if wifConfig.ID() != "" && wifConfig.DisplayName() != "" {
-			fmt.Printf("Wif-Config ID:          	%s\n", wifConfig.ID())
-			fmt.Printf("Wif-Config Name:          	%s\n", wifConfig.DisplayName())
-		}
+		printWifConfigData(connection, cluster)
 	}
 
 	channel := cluster.Channel()
@@ -408,7 +396,6 @@ func findHyperShiftMgmtSvcClusters(conn *sdk.Connection, cluster *cmv1.Cluster) 
 }
 
 func findWifConfig(connection *sdk.Connection, cluster *cmv1.Cluster) (*cmv1.WifConfig, error) {
-
 	wifConfig, err := connection.ClustersMgmt().
 		V1().
 		GCP().
@@ -482,4 +469,17 @@ func printManagedZone(connection *sdk.Connection, zoneId string) error {
 			gcp.FmtDnsZoneName(dnsDomain.Gcp().DomainPrefix(), dnsDomain.ID()))
 	}
 	return nil
+}
+
+func printWifConfigData(connection *sdk.Connection, cluster *cmv1.Cluster) {
+	if cluster.GCP() == nil || cluster.GCP().Authentication() == nil || cluster.GCP().Authentication().Id() == "" {
+		return
+	}
+	fmt.Printf("Wif-Config ID:          	%s\n", cluster.GCP().Authentication().Id())
+	wifConfig, err := findWifConfig(connection, cluster)
+	if err != nil {
+		// Will silently return if the client is not able to retrieve the WifConfig name, as this error is of minor impact.
+		return
+	}
+	fmt.Printf("Wif-Config Name:          	%s\n", wifConfig.DisplayName())
 }

--- a/tests/describe_cluster_test.go
+++ b/tests/describe_cluster_test.go
@@ -533,4 +533,292 @@ var _ = Describe("Describe clusters", func() {
 			))
 		})
 	})
+
+	When("Cluster uses WifConfig", func() {
+		var ssoServer *Server
+		var apiServer *Server
+		var config string
+
+		BeforeEach(func() {
+			// Create the servers:
+			ssoServer = MakeTCPServer()
+			apiServer = MakeTCPServer()
+
+			// Create the token:
+			accessToken := MakeTokenString("Bearer", 15*time.Minute)
+
+			// Prepare the server:
+			ssoServer.AppendHandlers(
+				RespondWithAccessToken(accessToken),
+			)
+
+			// Login:
+			result := NewCommand().
+				Args(
+					"login",
+					"--client-id", "my-client",
+					"--client-secret", "my-secret",
+					"--token-url", ssoServer.URL(),
+					"--url", apiServer.URL(),
+				).
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			config = result.ConfigString()
+
+			// Prepare the server to return data for an existing cluster:
+			apiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind": "SubscriptionList",
+						"page": 1,
+						"size": 1,
+						"total": 1,
+						"items": [
+						  {
+							"id": "111",
+							"kind": "Subscription",
+							"href": "/api/accounts_mgmt/v1/subscriptions/111",
+							"plan": {
+							  "id": "OSD",
+							  "kind": "Plan",
+							  "href": "/api/accounts_mgmt/v1/plans/OSD",
+							  "type": "OSD"
+							},
+							"creator": {
+								"id": "111",
+								"kind": "Account",
+								"href": "/api/accounts_mgmt/v1/accounts/111"
+							  },
+							"status": "Active",
+							"cluster_id": "111"
+						  }
+						]
+					  }`,
+				),
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind": "Cluster",
+						"id": "111",
+						"href": "/api/clusters_mgmt/v1/clusters/111",
+						"name": "test",
+						"external_id": "66e5d48c-6afd-475f-9236-e862071f899f",
+						"infra_id": "test-wtjvx",
+						"creation_timestamp": "2021-07-05T03:27:18.264654Z",
+						"activity_timestamp": "2021-07-13T06:55:32Z",
+						"expiration_timestamp": "2021-07-18T21:34:46Z",
+						"cloud_provider": {
+						  "kind": "CloudProviderLink",
+						  "id": "gcp",
+						  "href": "/api/clusters_mgmt/v1/cloud_providers/gcp"
+						},
+						"openshift_version": "4.7.18",
+						"subscription": {
+							"kind": "SubscriptionLink",
+							"id": "111",
+							"href": "/api/accounts_mgmt/v1/subscriptions/111"
+						},
+						"region": {
+						  "kind": "CloudRegionLink",
+						  "id": "ap-southeast-2",
+						  "href": "/api/clusters_mgmt/v1/cloud_providers/aws/regions/ap-southeast-2"
+						},
+						"console": {
+						  "url": "https://console-openshift-console.apps.test.example.org"
+						},
+						"api": {
+						  "url": "https://api.-test.example.org:6443",
+						  "listening": "external"
+						},
+						"nodes": {
+						  "master": 3,
+						  "infra": 2,
+						  "compute": 2,
+						  "availability_zones": [
+							"ap-southeast-2a"
+						  ]
+						},
+						"state": "ready",
+						"flavour": {
+						  "kind": "FlavourLink",
+						  "id": "osd-4",
+						  "href": "/api/clusters_mgmt/v1/flavours/osd-4"
+						},
+						"gcp": {
+							"authentication": {
+								"id": "WifConfigId"
+							}
+						},
+						"groups": {
+						  "kind": "GroupListLink",
+						  "href": "/api/clusters_mgmt/v1/clusters/111/groups"
+						},
+						"multi_az": false,
+						"managed": true,
+						"ccs": {
+						  "enabled": true,
+						  "disable_scp_checks": false
+						},
+						"version": {
+						  "kind": "Version",
+						  "id": "openshift-v4.7.18",
+						  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.7.18",
+						  "raw_id": "",
+						  "channel_group": "stable",
+						  "available_upgrades": [
+							"4.7.19"
+						  ]
+						},
+						"product": {
+						  "kind": "ProductLink",
+						  "id": "osd",
+						  "href": "/api/clusters_mgmt/v1/products/osd"
+						},
+						"status": {
+						  "state": "ready",
+						  "dns_ready": true,
+						  "provision_error_message": "",
+						  "provision_error_code": "",
+						  "configuration_mode": "full"
+						}
+					  }`,
+				),
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"id": "111",
+						"kind": "Subscription",
+						"href": "/api/accounts_mgmt/v1/subscriptions/111",
+						"support_level": "Premium",
+						"creator": {
+						  "id": "111",
+						  "kind": "Account",
+						  "href": "/api/accounts_mgmt/v1/accounts/111"
+						},
+						"managed": true,
+						"status": "Active"
+					  }`,
+				),
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"id": "111",
+						"kind": "Account",
+						"href": "/api/accounts_mgmt/v1/accounts/111",
+						"first_name": "Test",
+						"last_name": "Test",
+						"username": "test",
+						"email": "test@example.com",
+						"created_at": "2021-04-13T05:10:46.277747Z",
+						"updated_at": "2021-07-09T05:49:31.562355Z",
+						"organization": {
+						  "id": "111",
+						  "kind": "Organization",
+						  "href": "/api/accounts_mgmt/v1/organizations/111",
+						  "name": "Example Org"
+						}
+					  }`,
+				),
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"kind": "ProvisionShard",
+						"id": "111",
+						"href": "/api/clusters_mgmt/v1/provision_shards/111",
+						"hive_config": {
+						  "server": "https://api.shard1.example.com:6443"
+						},
+						"aws_account_operator_config": {
+						  "server": "https://api.shard1.example.com:6443"
+						},
+						"gcp_project_operator_config": {
+						  "server": "https://api.shard1.example.com:6443"
+						},
+						"aws_base_domain": "s1.test.org",
+						"gcp_base_domain": "s2.test.org",
+						"status": "active"
+					  }`,
+				),
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						  "Kind": "DnsDomain",
+						  "id": "0000.example.org",
+						  "href": "/api/clusters_mgmt/v1/dns_domains/0000.example.org",
+						  "organization": {
+							"kind": "OrganizationLink",
+							"id": "111",
+							"href": "/api/accounts_mgmt/v1/organizations/111"
+						  },
+						  "user_defined": true,
+						  "cluster_arch": "classic",
+						  "cloud_provider": "gcp",
+						  "gcp": {
+							"domain_prefix": "domain",
+							"project_id": "example-project",
+							"network_id": "example-network"
+						  }
+					}`,
+				),
+			)
+		})
+
+		AfterEach(func() {
+			// Close the servers:
+			ssoServer.Close()
+			apiServer.Close()
+		})
+		It("displays WifConfig id and name if it can retrieve it", func() {
+			apiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusOK,
+					`{
+						"Kind": "WifConfig",
+						"Id": "WifConfigId",
+						"Name": "WifConfigName"
+					}`,
+				),
+			)
+			// Run the command:
+			result := NewCommand().
+				ConfigString(config).
+				Args(
+					"describe", "cluster", "test",
+				).
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			lines := result.OutLines()
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(lines[1]).To(MatchRegexp(
+				`^\s*ID:\s+111\s*$`,
+			))
+
+			Expect(result.OutString()).To(ContainSubstring("Wif-Config ID:"))
+			Expect(result.OutString()).To(ContainSubstring("Wif-Config Name:"))
+		})
+		It("displays only the id if it can't retrieve the WifConfig name", func() {
+			apiServer.AppendHandlers(
+				RespondWithJSON(
+					http.StatusNotFound,
+					`{}`,
+				),
+			)
+			// Run the command:
+			result := NewCommand().
+				ConfigString(config).
+				Args(
+					"describe", "cluster", "test",
+				).
+				Run(ctx)
+			Expect(result.ExitCode()).To(BeZero())
+			lines := result.OutLines()
+			Expect(result.ErrString()).To(BeEmpty())
+			Expect(lines[1]).To(MatchRegexp(
+				`^\s*ID:\s+111\s*$`,
+			))
+
+			Expect(result.OutString()).To(ContainSubstring("Wif-Config ID:"))
+		})
+	})
 })


### PR DESCRIPTION
Changes:
- Refactor WifConfig display into printWifConfigData() function
- Always display WifConfig ID from cluster data (available directly)
- Silently handle errors when fetching WifConfig name (minor impact)
- Only show WifConfig name if successfully retrieved
- Add comprehensive test coverage for both success and error cases

This ensures backward compatibility with v1.0.6 behavior while still showing the WifConfig name when available.

## Description

<!-- Briefly describe the change and its motivation. -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] Unit tests pass (`make test`)
- [x] Integration tests pass (if applicable)
- [ ] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `describe cluster` output for environments using GCP-based authentication.
  * Wif-Config details are now displayed more reliably: the ID is shown when available, and the name is included only when it can be retrieved.
  * Prevented failures during Wif-Config lookup from disrupting cluster information display.
* **Tests**
  * Added command coverage to validate Wif-Config output for both successful retrieval and 404 “not found” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->