### PR TITLE
ROSA-745: Tide routing for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-   interval: "weekly"
-  open-pull-requests-limit: 20
+  - package-ecosystem: gomod
+    directory: "/"
+    labels:
+      - dependencies
+      - go
+      - lgtm
+      - approved
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 20

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    "config:best-practices"
+  ],
+  "enabledManagers": [
+    "gomod",
+    "tekton"
+  ],
+  "packageRules": [
+    {
+      "description": "ROSA-745: Tide — pre-label lgtm/approved; merge after Konflux + CI (no platform automerge)",
+      "matchManagers": [
+        "gomod",
+        "tekton"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": false,
+      "platformAutomerge": false,
+      "addLabels": [
+        "lgtm",
+        "approved"
+      ]
+    },
+    {
+      "description": "Major gomod/tekton — manual /lgtm after review",
+      "matchManagers": [
+        "gomod",
+        "tekton"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "platformAutomerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

[ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) — align **ocm-cli** with the Konflux + Tide dependency automerge path (same model as managed-cluster-validating-webhooks / boilerplate #786).

- Add `.github/renovate.json` for MintMaker (gomod + tekton): patch/minor/digest pre-label `lgtm` + `approved`, `automerge: false` / `platformAutomerge: false` so **Tide** merges after CI (not Renovate/Konflux platform automerge — [KFLUXSPRT-8235](https://redhat.atlassian.net/browse/KFLUXSPRT-8235)).
- Update `.github/dependabot.yml` with the same Tide labels on weekly gomod PRs.

**Follow-up (separate release PR):** branch-protection in `_prowconfig` with Konflux + GHA required contexts so Tide waits for `Red Hat Konflux / ocm-cli-on-pull-request`, `Lint`, and `Test (*)` before merging.

## Test plan

- [ ] After merge: next MintMaker patch/minor gomod PR gets `lgtm` + `approved` (no `automerge` label)
- [ ] Konflux + GHA green + Tide contexts → PR merges without manual click (once branch-protection PR lands)
- [ ] Major gomod/tekton MintMaker PRs open without pre-labels; require manual `/lgtm`
- [ ] Dependabot weekly gomod PRs get `lgtm` + `approved`; majors need human review before merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to better organize and label automated update pull requests.
  * Refined update rules so Go and Tekton dependency changes follow clearer review and approval handling.
  * Kept the existing weekly update cadence and pull request limits while improving consistency in update management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->