### PR TITLE
[Project Darkstar] ROSAENG-60663: Remediate 5 CVEs in ocm-cli (Go stdlib toolchain update to go1.25.11)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift-online/ocm-cli
 
 go 1.25.9
 
+toolchain go1.25.11
+
 require (
 	cloud.google.com/go/iam v1.11.0
 	cloud.google.com/go/storage v1.63.1


### PR DESCRIPTION
## Project Darkstar — Automated CVE Remediation

> **This PR was generated by Project Darkstar**, an automated CVE remediation tool.
> For questions or concerns, contact **Kevin Seiter** (ROSA Trust Engineering).

## Summary
- Adds `toolchain go1.25.11` to go.mod to remediate 5 Important-severity Go standard library CVEs
- Updates Go toolchain from go1.25.9 to go1.25.11 (minimum patch bumps: 1.25.10 for net CVEs, 1.25.11 for mime/x509 CVEs)
- Additionally notes 2 CVEs already fixed via golang.org/x/net v0.57.0 (>= fix version v0.55.0)

## CVE Details

| CVE | Severity | CVSS | Component | Fix |
|-----|----------|------|-----------|-----|
| CVE-2026-42504 | Important | 7.5 | Go stdlib mime | go1.25.11 |
| CVE-2026-27145 | Important | 7.5 | Go stdlib crypto/x509 | go1.25.11 |
| CVE-2026-39820 | Important | 7.5 | Go stdlib net/mail | go1.25.11 |
| CVE-2026-33811 | Important | 7.5 | Go stdlib net | go1.25.11 |
| CVE-2026-42499 | Important | 7.5 | Go stdlib net/mail | go1.25.11 |

## Already Fixed (no action needed)
- CVE-2026-27136 (golang.org/x/net/html XSS) — golang.org/x/net v0.57.0 >= fix version v0.55.0
- CVE-2026-25681 (golang.org/x/net/html XSS) — golang.org/x/net v0.57.0 >= fix version v0.55.0

## Changes
- `go.mod`: Added `toolchain go1.25.11` directive after `go 1.25.9`
- `go.sum`: Updated by `go mod tidy`

## Verification
- [x] `go mod tidy` completed successfully
- [x] `go build ./...` passes with no errors
- [x] Minimum-viable version applied (go1.25.11 = lowest version fixing all 5 stdlib CVEs)

## References
- [ROSAENG-60663](https://redhat.atlassian.net/browse/ROSAENG-60663): https://issues.redhat.com/browse/ROSAENG-60663 (CVE-2026-42504)
- [ROSAENG-60656](https://redhat.atlassian.net/browse/ROSAENG-60656): https://issues.redhat.com/browse/ROSAENG-60656 (CVE-2026-27145)
- [ROSAENG-60523](https://redhat.atlassian.net/browse/ROSAENG-60523): https://issues.redhat.com/browse/ROSAENG-60523 (CVE-2026-39820)
- [ROSAENG-60383](https://redhat.atlassian.net/browse/ROSAENG-60383): https://issues.redhat.com/browse/ROSAENG-60383 (CVE-2026-33811)
- [ROSAENG-60352](https://redhat.atlassian.net/browse/ROSAENG-60352): https://issues.redhat.com/browse/ROSAENG-60352 (CVE-2026-42499)
- Go 1.25.10 release: https://groups.google.com/g/golang-announce/c/qcCIEXso47M
- Go 1.25.11 release: https://groups.google.com/g/golang-dev/c/PcoAeCoqmm0
- NVD CVE-2026-42504: https://nvd.nist.gov/vuln/detail/CVE-2026-42504
- NVD CVE-2026-27145: https://nvd.nist.gov/vuln/detail/CVE-2026-27145

---
**Project Darkstar** — Automated CVE Remediation | Contact: Kevin Seiter (ROSA Trust Engineering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain version to 1.25.11.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->