### PR TITLE
ROSAENG-62579: Accept Warning and Moderate service-log severities

### DIFF
--- a/pkg/cluster/describe.go
+++ b/pkg/cluster/describe.go
@@ -423,6 +423,13 @@ func getAuthenticationDisplayName(authKind string) string {
 	}
 }
 
+// isWarningSeverity reports whether a service-log severity should be shown as a
+// create-time warning. Accepts both legacy Warning and HCC Moderate labels so
+// banners keep working across the OSL Phase 2 cutover.
+func isWarningSeverity(severity slv1.Severity) bool {
+	return severity == slv1.SeverityWarning || severity == slv1.SeverityModerate
+}
+
 // PrintClusterWarnings retrieves and displays warning-level service log entries for
 // a cluster. It queries the Service Logs API across all pages and outputs any warning
 // messages with their summary and description.
@@ -444,7 +451,7 @@ func PrintClusterWarnings(connection *sdk.Connection, cluster *cmv1.Cluster) err
 
 		// Process warning entries from this page
 		serviceLogs.Items().Each(func(entry *slv1.LogEntry) bool {
-			if entry.Severity() == slv1.SeverityWarning {
+			if isWarningSeverity(entry.Severity()) {
 				fmt.Printf("⚠️ WARNING:\n%s\n%s\n", entry.Summary(), entry.Description())
 			}
 			return true

--- a/pkg/cluster/describe_test.go
+++ b/pkg/cluster/describe_test.go
@@ -1,9 +1,34 @@
 package cluster
 
 import (
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"testing"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	slv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 )
+
+func TestIsWarningSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity slv1.Severity
+		want     bool
+	}{
+		{name: "legacy Warning", severity: slv1.SeverityWarning, want: true},
+		{name: "HCC Moderate", severity: slv1.SeverityModerate, want: true},
+		{name: "Info", severity: slv1.SeverityInfo, want: false},
+		{name: "Debug", severity: slv1.SeverityDebug, want: false},
+		{name: "empty", severity: "", want: false},
+		{name: "Important", severity: slv1.SeverityImportant, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isWarningSeverity(test.severity); got != test.want {
+				t.Errorf("isWarningSeverity(%q) = %v, want %v", test.severity, got, test.want)
+			}
+		})
+	}
+}
 
 // newTestCluster assembles a *cmv1.Cluster while handling the error to help out with inline test-case generation
 func newTestCluster(t *testing.T, cb *cmv1.ClusterBuilder) *cmv1.Cluster {


### PR DESCRIPTION
## Description

After `ocm create cluster`, `PrintClusterWarnings` only surfaces service-log entries with severity `Warning`. OSL Phase 2 ([ROSAENG-59901](https://redhat.atlassian.net/browse/ROSAENG-59901)) maps API reads from `Warning` → `Moderate`, which would silence those banners.

This change treats both legacy `Warning` (`slv1.SeverityWarning`) and HCC `Moderate` (`slv1.SeverityModerate`) as printable warning severities.

Jira: [ROSAENG-62579](https://redhat.atlassian.net/browse/ROSAENG-62579)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

- [x] Unit tests pass (`go test ./pkg/cluster/ -run TestIsWarningSeverity`)
- [ ] Integration tests pass (if applicable)
- [ ] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster warnings now include service log entries with moderate severity, in addition to legacy warning entries.
  * Warning summaries and descriptions continue to display as before.

* **Tests**
  * Added coverage for warning detection across supported and non-warning severity levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->