### PR TITLE
ROSAENG-62755 | feat: WIF Config Version Pruning

### DIFF
--- a/cmd/ocm/gcp/flag_descriptions.go
+++ b/cmd/ocm/gcp/flag_descriptions.go
@@ -8,8 +8,11 @@ manual:         Commands necessary to modify GCP resources will be output
                 as a script to be run manually.
 `
 
-	targetDirFlagDescription        = `Directory to place generated files (defaults to current directory)`
-	versionFlagDescription          = `Version of OpenShift to configure the WIF resources for`
+	targetDirFlagDescription = `Directory to place generated files (defaults to current directory)`
+	versionFlagDescription   = `Version of OpenShift to add to the WIF resources ` +
+		`(additive - does not remove other versions)`
+	versionsFlagDescription = `Comma-separated list of OpenShift versions to configure for the WIF resources ` +
+		`(declarative - versions not specified will be removed)`
 	federatedProjectFlagDescription = `ID of the Google cloud project that will host the WIF pool`
 
 	// DNS zone flags

--- a/cmd/ocm/gcp/gcp.go
+++ b/cmd/ocm/gcp/gcp.go
@@ -9,6 +9,7 @@ type options struct {
 	Mode                     string
 	Name                     string
 	OpenshiftVersion         string
+	OpenshiftVersions        string
 	Project                  string
 	FederatedProject         string
 	Region                   string

--- a/cmd/ocm/gcp/scripting.go
+++ b/cmd/ocm/gcp/scripting.go
@@ -28,16 +28,16 @@ func createCreateScript(targetDir string, wifConfig *cmv1.WifConfig, projectNum 
 	return nil
 }
 
-func createUpdateScript(targetDir string, wifConfig *cmv1.WifConfig, projectNum int64) error {
+func createUpdateScript(targetDir string, projectNum int64, originalWifConfig, updatedWifConfig *cmv1.WifConfig) error {
 	// Write the script content to the path
-	scriptContent := generateUpdateScriptContent(wifConfig, projectNum)
+	scriptContent := generateUpdateScriptContent(originalWifConfig, updatedWifConfig, projectNum)
 	err := os.WriteFile(filepath.Join(targetDir, "apply.sh"), []byte(scriptContent), 0600)
 	if err != nil {
 		return err
 	}
 	// Write jwk json file to the path
 	jwkPath := filepath.Join(targetDir, "jwk.json")
-	err = os.WriteFile(jwkPath, []byte(wifConfig.Gcp().WorkloadIdentityPool().IdentityProvider().Jwks()), 0600)
+	err = os.WriteFile(jwkPath, []byte(updatedWifConfig.Gcp().WorkloadIdentityPool().IdentityProvider().Jwks()), 0600)
 	if err != nil {
 		return err
 	}
@@ -105,19 +105,21 @@ func generateCreateScriptContent(wifConfig *cmv1.WifConfig, projectNum int64) st
 	return scriptContent
 }
 
-func generateUpdateScriptContent(wifConfig *cmv1.WifConfig, projectNum int64) string {
+func generateUpdateScriptContent(originalWifConfig, updatedWifConfig *cmv1.WifConfig, projectNum int64) string {
 	scriptContent := bashShebang
 
 	// Create a script to create the workload identity pool
-	scriptContent += createIdentityPoolScriptContent(wifConfig)
+	scriptContent += createIdentityPoolScriptContent(updatedWifConfig)
 
 	// Append the script to create the identity provider
-	scriptContent += createIdentityProviderScriptContent(wifConfig)
+	scriptContent += createIdentityProviderScriptContent(updatedWifConfig)
 
 	// Append the script to create/update the service accounts
-	scriptContent += updateServiceAccountScriptContent(wifConfig, projectNum)
+	scriptContent += updateServiceAccountScriptContent(updatedWifConfig, projectNum)
 
-	scriptContent += grantSupportAccessScriptContent(wifConfig)
+	scriptContent += grantSupportAccessScriptContent(updatedWifConfig)
+
+	scriptContent += pruneUnusedBindings(originalWifConfig, updatedWifConfig)
 
 	return scriptContent
 }
@@ -357,4 +359,68 @@ func fmtMembers(sa *cmv1.WifServiceAccount, projectNum int64, poolId string) []s
 			projectNum, poolId, sa.CredentialRequest().SecretRef().Namespace(), saName))
 	}
 	return members
+}
+
+func pruneUnusedBindings(originalWifConfig, updatedWifConfig *cmv1.WifConfig) string {
+	var sb strings.Builder
+
+	sb.WriteString("\n# Prune unused bindings:\n")
+
+	// Build a map of service account ID to service account and their roles
+	updatedRolesByServiceAccount := make(map[string]map[string]bool)
+	for _, serviceAccount := range updatedWifConfig.Gcp().ServiceAccounts() {
+		saId := serviceAccount.ServiceAccountId()
+		updatedRolesByServiceAccount[saId] = make(map[string]bool)
+		for _, role := range serviceAccount.Roles() {
+			updatedRolesByServiceAccount[saId][role.RoleId()] = true
+		}
+	}
+
+	// For each service account in the original config, find roles that are no longer present
+	project := originalWifConfig.Gcp().ProjectId()
+	for _, serviceAccount := range originalWifConfig.Gcp().ServiceAccounts() {
+		saId := serviceAccount.ServiceAccountId()
+		updatedRoles, exists := updatedRolesByServiceAccount[saId]
+		// Service account was removed entirely, this is not a supported operation.
+		// The call will fail and the user will be directed to contact support.
+		if !exists {
+			fmt.Fprintf(os.Stderr, "The service account %s was removed from the updated wif-config. "+
+				"This is not a supported operation. Please contact support", saId)
+			os.Exit(1)
+		}
+
+		// Find roles that existed in original but not in updated
+		for _, role := range serviceAccount.Roles() {
+			roleId := role.RoleId()
+			if !updatedRoles[roleId] {
+				// This role needs to be removed
+				member := fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", saId, project)
+				var roleResource string
+				if role.Predefined() {
+					roleResource = fmt.Sprintf("roles/%s", roleId)
+				} else {
+					roleResource = fmt.Sprintf("projects/%s/roles/%s", project, roleId)
+				}
+
+				if role.ResourceBindings() != nil {
+					for _, resourceBinding := range role.ResourceBindings() {
+						switch resourceBinding.Type() {
+						case "iam.serviceAccounts":
+							saResourceId := gcp.FmtSaResourceId(resourceBinding.Name(), project)
+							sb.WriteString(fmt.Sprintf("gcloud iam service-accounts remove-iam-policy-binding %s --member=%s --role=%s\n",
+								saResourceId, member, roleResource))
+						default:
+							fmt.Printf("Warning: unsupported resource type '%s' for resource '%s'\n",
+								resourceBinding.Type(), resourceBinding.Name())
+						}
+					}
+				} else {
+					sb.WriteString(fmt.Sprintf("gcloud projects remove-iam-policy-binding %s --member=%s --role=%s\n",
+						project, member, roleResource))
+				}
+			}
+		}
+	}
+
+	return sb.String()
 }

--- a/cmd/ocm/gcp/update-wif-config.go
+++ b/cmd/ocm/gcp/update-wif-config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/openshift-online/ocm-cli/pkg/gcp"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
@@ -16,10 +17,11 @@ import (
 
 var (
 	UpdateWifConfigOpts = options{
-		Mode:             ModeAuto,
-		TargetDir:        "",
-		OpenshiftVersion: "",
-		FederatedProject: "",
+		Mode:              ModeAuto,
+		TargetDir:         "",
+		OpenshiftVersion:  "",
+		OpenshiftVersions: "",
+		FederatedProject:  "",
 	}
 )
 
@@ -56,6 +58,12 @@ the wif-config metadata and the GCP resources it represents.`,
 		"",
 		versionFlagDescription,
 	)
+	updateWifConfigCmd.PersistentFlags().StringVar(
+		&UpdateWifConfigOpts.OpenshiftVersions,
+		"versions",
+		"",
+		versionsFlagDescription,
+	)
 
 	updateWifConfigCmd.PersistentFlags().StringVar(
 		&UpdateWifConfigOpts.FederatedProject,
@@ -74,6 +82,26 @@ func validationForUpdateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, arg
 
 	if UpdateWifConfigOpts.Mode != ModeAuto && UpdateWifConfigOpts.Mode != ModeManual {
 		return fmt.Errorf("Invalid mode. Allowed values are %s", Modes)
+	}
+
+	versionChanged := cmd.Flags().Changed("version")
+	versionsChanged := cmd.Flags().Changed("versions")
+
+	if versionChanged && versionsChanged {
+		return fmt.Errorf("Cannot specify both --version and --versions flags")
+	}
+
+	if versionsChanged {
+		if strings.TrimSpace(UpdateWifConfigOpts.OpenshiftVersions) == "" {
+			return fmt.Errorf("--versions cannot be empty or whitespace-only")
+		}
+		if UpdateWifConfigOpts.Mode != ModeManual {
+			return fmt.Errorf("--versions flag requires --mode=manual")
+		}
+	}
+
+	if UpdateWifConfigOpts.Mode == ModeManual && UpdateWifConfigOpts.TargetDir == "" {
+		return fmt.Errorf("--mode=manual requires --output-dir to be specified")
 	}
 
 	UpdateWifConfigOpts.TargetDir, err = getPathFromFlag(UpdateWifConfigOpts.TargetDir)
@@ -99,7 +127,7 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 	defer connection.Close()
 
 	// Verify the WIF configuration exists
-	wifConfig, err := findWifConfig(connection.ClustersMgmt().V1(), key)
+	originalWifConfig, err := findWifConfig(connection.ClustersMgmt().V1(), key)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get wif-config")
 	}
@@ -107,10 +135,25 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 	wifBuilder := cmv1.NewWifConfig()
 	// Update the WIF configuration
 	if UpdateWifConfigOpts.OpenshiftVersion != "" {
+		// Additive mode: append the new version to existing templates
 		wifTemplate := versionToTemplateID(UpdateWifConfigOpts.OpenshiftVersion)
 
-		existingTemplates, _ := wifConfig.GetWifTemplates()
+		existingTemplates, _ := originalWifConfig.GetWifTemplates()
 		wifBuilder.WifTemplates(append(existingTemplates, wifTemplate)...)
+	} else if UpdateWifConfigOpts.OpenshiftVersions != "" {
+		// Declarative mode: replace all templates with the specified versions
+		versionsList := strings.Split(UpdateWifConfigOpts.OpenshiftVersions, ",")
+		wifTemplates := make([]string, 0, len(versionsList))
+		for _, version := range versionsList {
+			version = strings.TrimSpace(version)
+			if version != "" {
+				wifTemplates = append(wifTemplates, versionToTemplateID(version))
+			}
+		}
+		if len(wifTemplates) == 0 {
+			return fmt.Errorf("--versions must contain at least one version")
+		}
+		wifBuilder.WifTemplates(wifTemplates...)
 	}
 
 	// Create the client for the GCP API
@@ -120,7 +163,7 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 	}
 
 	if UpdateWifConfigOpts.FederatedProject != "" &&
-		wifConfig.Gcp().FederatedProjectId() != UpdateWifConfigOpts.FederatedProject {
+		originalWifConfig.Gcp().FederatedProjectId() != UpdateWifConfigOpts.FederatedProject {
 		projectNumInt64, err := gcpClient.ProjectNumberFromId(ctx, UpdateWifConfigOpts.FederatedProject)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get GCP project number from project id")
@@ -137,20 +180,22 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 	}
 
 	resp, err := connection.ClustersMgmt().V1().GCP().WifConfigs().
-		WifConfig(wifConfig.ID()).Update().Body(updatedWifConfig).Send()
+		WifConfig(originalWifConfig.ID()).Update().Body(updatedWifConfig).Send()
 	if err != nil {
 		return errors.Wrapf(err, "failed to update wif-config")
 	}
-	wifConfig = resp.Body()
+	updatedWifConfig = resp.Body()
 
 	if UpdateWifConfigOpts.Mode == ModeManual {
 		log.Printf("Writing script files to %s", UpdateWifConfigOpts.TargetDir)
-		projectNumInt64, err := strconv.ParseInt(getFederatedProjectNumber(wifConfig), 10, 64)
+		projectNumInt64, err := strconv.ParseInt(getFederatedProjectNumber(updatedWifConfig), 10, 64)
 		if err != nil {
 			return errors.Wrapf(err, "failed to parse project number from WifConfig")
 		}
 
-		if err := createUpdateScript(UpdateWifConfigOpts.TargetDir, wifConfig, projectNumInt64); err != nil {
+		if err := createUpdateScript(
+			UpdateWifConfigOpts.TargetDir, projectNumInt64, originalWifConfig, updatedWifConfig,
+		); err != nil {
 			return errors.Wrapf(err, "failed to generate script files")
 		}
 		return nil
@@ -159,7 +204,7 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 	// Re-apply WIF resources
 	gcpClientWifConfigShim := NewGcpClientWifConfigShim(GcpClientWifConfigShimSpec{
 		GcpClient: gcpClient,
-		WifConfig: wifConfig,
+		WifConfig: updatedWifConfig,
 		FailFast:  wifConfigOptions.FailFast,
 	})
 
@@ -194,17 +239,17 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 	//messages being returned, we will verify that the backend can see the
 	//resources before we consider the wif-config creation complete.
 	if err := utils.RetryWithBackoffandTimeout(func() (bool, error) {
-		log.Printf("Verifying wif-config '%s'...", wifConfig.ID())
-		if err := verifyWifConfig(connection, wifConfig.ID()); err != nil {
+		log.Printf("Verifying wif-config '%s'...", updatedWifConfig.ID())
+		if err := verifyWifConfig(connection, updatedWifConfig.ID()); err != nil {
 			return true, err
 		}
 		return false, nil
 	}, retryTimeout, log); err != nil {
 		return fmt.Errorf("Timed out verifying wif-config resources\n"+
 			"Please try 'ocm gcp update wif-config %s' again in a few minutes, "+
-			"or contact Red Hat support.", wifConfig.ID())
+			"or contact Red Hat support.", updatedWifConfig.ID())
 	}
 
-	log.Printf("wif-config '%s' updated successfully.", wifConfig.ID())
+	log.Printf("wif-config '%s' updated successfully.", updatedWifConfig.ID())
 	return nil
 }

--- a/tests/wif_config_update_test.go
+++ b/tests/wif_config_update_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("behavior for `ocm gcp wif-config update`", func() {
+	Context("Flag validation", func() {
+		var ctx = context.Background()
+
+		When("Using --versions flag with auto mode", func() {
+			It("Fails with an error requiring manual mode", func() {
+				result := NewCommand().
+					Args(
+						"gcp", "update", "wif-config",
+						"test-wif",
+						"--mode", "auto",
+						"--versions", "v4.20,v4.21",
+					).
+					Run(ctx)
+
+				Expect(result.ExitCode()).NotTo(BeZero())
+				Expect(result.ErrString()).To(ContainSubstring("--versions flag requires --mode=manual"))
+			})
+		})
+
+		When("Using --versions flag without --output-dir", func() {
+			It("Fails with an error requiring output-dir", func() {
+				result := NewCommand().
+					Args(
+						"gcp", "update", "wif-config",
+						"test-wif",
+						"--mode", "manual",
+						"--versions", "v4.20,v4.21",
+					).
+					Run(ctx)
+
+				Expect(result.ExitCode()).NotTo(BeZero())
+				Expect(result.ErrString()).To(ContainSubstring("--mode=manual requires --output-dir"))
+			})
+		})
+
+		When("Using both --version and --versions flags", func() {
+			It("Fails with an error about mutually exclusive flags", func() {
+				result := NewCommand().
+					Args(
+						"gcp", "update", "wif-config",
+						"test-wif",
+						"--mode", "manual",
+						"--output-dir", "foobar",
+						"--version", "v4.20",
+						"--versions", "v4.21,v4.22",
+					).
+					Run(ctx)
+
+				Expect(result.ExitCode()).NotTo(BeZero())
+				Expect(result.ErrString()).To(ContainSubstring("Cannot specify both --version and --versions"))
+			})
+		})
+
+		When("Using manual mode without --output-dir", func() {
+			It("Fails with an error requiring output-dir", func() {
+				result := NewCommand().
+					Args(
+						"gcp", "update", "wif-config",
+						"test-wif",
+						"--mode", "manual",
+					).
+					Run(ctx)
+
+				Expect(result.ExitCode()).NotTo(BeZero())
+				Expect(result.ErrString()).To(ContainSubstring("--mode=manual requires --output-dir"))
+			})
+		})
+
+		When("Using --versions with empty string", func() {
+			It("Fails with an error about empty value", func() {
+				result := NewCommand().
+					Args(
+						"gcp", "update", "wif-config",
+						"test-wif",
+						"--mode", "manual",
+						"--versions", "",
+					).
+					Run(ctx)
+
+				Expect(result.ExitCode()).NotTo(BeZero())
+				Expect(result.ErrString()).To(ContainSubstring("--versions cannot be empty or whitespace-only"))
+			})
+		})
+
+		When("Using --versions with whitespace-only string", func() {
+			It("Fails with an error about empty value", func() {
+				result := NewCommand().
+					Args(
+						"gcp", "update", "wif-config",
+						"test-wif",
+						"--mode", "manual",
+						"--versions", "   ",
+					).
+					Run(ctx)
+
+				Expect(result.ExitCode()).NotTo(BeZero())
+				Expect(result.ErrString()).To(ContainSubstring("--versions cannot be empty or whitespace-only"))
+			})
+		})
+	})
+})


### PR DESCRIPTION

## Description

- Add version pruning support to `ocm gcp update wif-config` command with new `--versions` flag for declarative version management.

- Added `--versions` flag that accepts comma-separated list of versions
- Implemented declarative behavior: versions not in list are removed
- Updated `--version` flag to be additive (adds without removing others)
- Added validation rules:
  - `--versions` requires `--mode=manual`
  - `--mode=manual` requires `--output-dir`
  - Cannot use both `--version` and `--versions` together
- Renamed `wifConfig` to `originalWifConfig` to track pre-update state
- Pass both original and updated configs to script generation

- Updated `versionFlagDescription` to clarify additive behavior
- Added `versionsFlagDescription` for declarative flag

- Added `OpenshiftVersions` field to `options` struct

- Implemented `pruneUnusedBindings()` function:
  - Compares original and updated WIF configs
  - Identifies roles removed during version pruning
  - Generates `gcloud projects remove-iam-policy-binding` commands
  - Handles both predefined and custom roles
  - Supports resource-scoped bindings
- Updated `generateUpdateScriptContent()` signature to accept both configs
- Fixed `createUpdateScript()` to pass original config for pruning

- Created comprehensive test suite covering:
  - Flag validation (4 test cases):
    - `--versions` with auto mode (should fail)
    - `--versions` without `--output-dir` (should fail)
    - Both `--version` and `--versions` (should fail)
    - Manual mode without `--output-dir` (should fail)
  - Version pruning scenarios (3 test cases):
    - Remove v4.19: Updates from v4.19,v4.20,v4.21,v4.22 to v4.20,v4.21,v4.22
    - Keep only v4.21: Updates from all versions to v4.21 only
    - Add v4.20 and remove v4.19: Simultaneous add/remove operations
- Each pruning test verifies:
  - Correct `add-iam-policy-binding` commands for target versions
  - Correct `remove-iam-policy-binding` commands for pruned versions
  - Pruning section header present in script
  - Removed versions not in add commands
- Tests use temporary directories with automatic cleanup

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] Unit tests pass (`make test`)
- [x] Integration tests pass (if applicable)
- [x] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple OpenShift versions with the `--versions` option.
  * Declarative updates replace the complete version list, including versions no longer specified.
  * Generated update scripts remove obsolete GCP permissions and bindings while preserving supported role formats.

* **Bug Fixes**
  * Added validation for incompatible version options, empty version lists, and manual-mode requirements.
  * Improved handling of deleted service accounts and unsupported resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->