### PR TITLE
ROSAENG-66151 | wif update generates separate pruning script

### DIFF
--- a/cmd/ocm/gcp/scripting.go
+++ b/cmd/ocm/gcp/scripting.go
@@ -44,6 +44,16 @@ func createUpdateScript(targetDir string, projectNum int64, originalWifConfig, u
 	return nil
 }
 
+func createPruneScript(targetDir string, originalWifConfig, updatedWifConfig *cmv1.WifConfig) error {
+	// Write the script content to the path
+	scriptContent := generatePruneScriptContent(originalWifConfig, updatedWifConfig)
+	err := os.WriteFile(filepath.Join(targetDir, "prune.sh"), []byte(scriptContent), 0600)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func createDeleteScript(targetDir string, wifConfig *cmv1.WifConfig) error {
 	// Write the script content to the path
 	scriptContent := generateDeleteScriptContent(wifConfig)
@@ -118,6 +128,11 @@ func generateUpdateScriptContent(originalWifConfig, updatedWifConfig *cmv1.WifCo
 	scriptContent += updateServiceAccountScriptContent(updatedWifConfig, projectNum)
 
 	scriptContent += grantSupportAccessScriptContent(updatedWifConfig)
+	return scriptContent
+}
+
+func generatePruneScriptContent(originalWifConfig, updatedWifConfig *cmv1.WifConfig) string {
+	scriptContent := bashShebang
 
 	scriptContent += pruneUnusedBindings(originalWifConfig, updatedWifConfig)
 

--- a/cmd/ocm/gcp/update-wif-config.go
+++ b/cmd/ocm/gcp/update-wif-config.go
@@ -196,7 +196,12 @@ func updateWorkloadIdentityConfigurationCmd(cmd *cobra.Command, argv []string) e
 		if err := createUpdateScript(
 			UpdateWifConfigOpts.TargetDir, projectNumInt64, originalWifConfig, updatedWifConfig,
 		); err != nil {
-			return errors.Wrapf(err, "failed to generate script files")
+			return errors.Wrapf(err, "failed to generate update script file")
+		}
+		if err := createPruneScript(
+			UpdateWifConfigOpts.TargetDir, originalWifConfig, updatedWifConfig,
+		); err != nil {
+			return errors.Wrapf(err, "failed to generate prune script file")
 		}
 		return nil
 	}


### PR DESCRIPTION
## Description

<!-- Briefly describe the change and its motivation. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [x] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [x] Manual verification completed

```
rcampos@rcampos-thinkpadp1gen4i:~/tmp/workspace/repos/ocm-cli$ ocm gcp create wif-config --project sda-ccs-1 --mode manual --output-dir /tmp/ --name foobar
2026/09/01 16:45:13 Writing script files to /tmp/
rcampos@rcampos-thinkpadp1gen4i:~/tmp/workspace/repos/ocm-cli$ ./ocm gcp update wif-config foobar --versions v4.21 --mode manual --output-dir /tmp/prune
2026/09/01 16:45:52 Writing script files to /tmp/prune
rcampos@rcampos-thinkpadp1gen4i:~/tmp/workspace/repos/ocm-cli$ less /tmp/prune/prune.sh
rcampos@rcampos-thinkpadp1gen4i:~/tmp/workspace/repos/ocm-cli$ cat /tmp/prune/prune.sh  | wc -l
27
rcampos@rcampos-thinkpadp1gen4i:~/tmp/workspace/repos/ocm-cli$ # Verified contents of generated script.

```
## Checklist

- [x] My code follows the project's coding conventions
- [x] I have updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic generation of a pruning script for updated GCP workload identity configurations.
  * Manual updates now produce separate scripts for applying changes and removing unused bindings.

* **Bug Fixes**
  * Improved error reporting by distinguishing update-script and prune-script generation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->