### PR TITLE
ROSAENG-66495 | fix: generate scripts for fw ops should not terminate on fail

### DIFF
--- a/pkg/gcp/firewall_rules.go
+++ b/pkg/gcp/firewall_rules.go
@@ -29,8 +29,6 @@ func GenerateCreateBashScript(fr *FirewallRuleset) string {
 	fmt.Fprintf(&sb, "NETWORK=%s\n", shellQuote(fr.GcpNetwork().VpcName()))
 	fmt.Fprintf(&sb, "PREFIX=%s\n\n", shellQuote(fr.Name()))
 
-	sb.WriteString("set -e\n\n")
-
 	for i, rule := range fr.Status().Rules() {
 		if i > 0 {
 			sb.WriteString("\n")
@@ -98,8 +96,6 @@ func GenerateDeleteBashScript(fr *FirewallRuleset) string {
 	fmt.Fprintf(&sb, "NETWORK=%s\n", shellQuote(fr.GcpNetwork().VpcName()))
 	fmt.Fprintf(&sb, "PREFIX=%s\n\n", shellQuote(fr.Name()))
 
-	sb.WriteString("set -e\n\n")
-
 	for i, rule := range fr.Status().Rules() {
 		if i > 0 {
 			sb.WriteString("\n")
@@ -134,8 +130,6 @@ func GenerateUpdateBashScript(fr *FirewallRuleset) string {
 	fmt.Fprintf(&sb, "PROJECT=%s\n", shellQuote(fr.GcpNetwork().ProjectId()))
 	fmt.Fprintf(&sb, "NETWORK=%s\n", shellQuote(fr.GcpNetwork().VpcName()))
 	fmt.Fprintf(&sb, "PREFIX=%s\n\n", shellQuote(fr.Name()))
-
-	sb.WriteString("set -e\n\n")
 
 	for i, rule := range fr.Status().Rules() {
 		if i > 0 {


### PR DESCRIPTION
## Description

<!-- Briefly describe the change and its motivation. -->
ocm cli scripts for creating/updating/deleting wif config  and firewall rules should not exit if one of its commands fail. 

As an example:

Running the script generated for deleting firewall rules, if a firewall rule has already been delete, the script terminates early as that deletion call fails. It should instead continue removing the other firewall rules.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or tooling change

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [ ] Unit tests pass (`make test`)
- [ ] Integration tests pass (if applicable)
- [x] Manual verification completed

## Checklist

- [x] My code follows the project's coding conventions
- [ ] I have updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Firewall rule scripts no longer stop immediately after a command returns an error, allowing subsequent commands to continue running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->